### PR TITLE
LINGUAS should list language name on each line

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,1 +1,3 @@
-fr ja ko
+fr
+ja
+ko


### PR DESCRIPTION
intltool's Makefile.in.in looks up specified language code using:

http://bazaar.launchpad.net/~intltool/intltool/trunk/view/head:/Makefile.in.in#L59

>  USER_LINGUAS=(snip)if test -n "`grep \^$$lang$$ $(srcdir)/LINGUAS 2>/dev/null`"(snip)

This code snippet means that LINGUAS is expected to list each
supported language name on each line one by one.

This patch simply fix current LINGUAS to follow such manner and
let translation files properly generated.
