### PR TITLE
Hide/show candidate window via generic option

### DIFF
--- a/scm/m17nlib.scm
+++ b/scm/m17nlib.scm
@@ -30,6 +30,7 @@
 
 (require-custom "generic-key-custom.scm")
 (require-custom "m17nlib-custom.scm")
+(require-custom "generic-custom.scm")
 
 ;;; user configs
 


### PR DESCRIPTION
Problem: Add new option to show/hide the candidate window for `m1n`.

See description below. There is some typo error but as the commit is shared I wouldn't change it. If you have any questions please let me know.

```
Adding a new option to "m17nlib.scm" to add new option is
still possible, however we just need to use the known option.
This may cause confusion, because "Other input methods" (that
is that name of "Generic") often excludes "m17n-lib". So
it is a feature (possibly a bug) that "m17n-lib" uses a
generic option for its. This also requires dependencies,
and we will not be able to have a separated settings for "m
17n-lib". This is almost good, bc. showing/hiding the window
for candidates may be a personal setting: someone just likes
to see them all (for any input methods/settings), while some
others just like to see nothing
```
