### PR TITLE
+ config. to set default mode for generic IM

### DIFF
--- a/scm/generic-custom.scm
+++ b/scm/generic-custom.scm
@@ -36,6 +36,12 @@
 		     (N_ "Other input methods")
 		     (N_ "long description will be here."))
 
+(define-custom 'generic-im-default-state-on? #f
+  '(other-ims miscellaneous)
+  '(boolean)
+  (N_ "Default input mode is on")
+  (N_ "long description will be here."))
+
 (define-custom 'generic-use-candidate-window? #t
   '(other-ims candwin)
   '(boolean)

--- a/scm/generic.scm
+++ b/scm/generic.scm
@@ -40,13 +40,16 @@
 (define generic-widgets '(widget_generic_input_mode))
 
 ;; default activity for each widgets
-(define default-widget_generic_input_mode 'action_generic_off)
+(define default-widget_generic_input_mode
+  (cond
+    (generic-im-default-state-on? 'action_generic_on)
+    (else 'action_generic_off)
+  ))
 
 ;; actions of widget_generic_input_mode
 (define generic-input-mode-actions
   '(action_generic_off
     action_generic_on))
-
 
 ;;; implementations
 
@@ -61,6 +64,9 @@
   (lambda (gc)
     (let ((rkc (generic-context-rk-context gc)))
       (rk-flush rkc)
+      (cond
+        (generic-im-default-state-on? 'action_generic_on)
+        (else 'action_generic_off))
       (generic-update-preedit gc))))
 
 (register-action 'action_generic_off

--- a/scm/im-custom.scm
+++ b/scm/im-custom.scm
@@ -86,6 +86,11 @@
 		     (N_ "long description will be here."))
 
 ;; subgroup
+(define-custom-group 'miscellaneous
+		     (N_ "Miscellaneous settings")
+		     (N_ "long description will be here."))
+
+;; subgroup
 (define-custom-group 'dictionary
                      (N_ "Dictionary")
                      (N_ "long description will be here."))


### PR DESCRIPTION
Commit message

```
New configuration option allows user to select default mode
for generic IM. This is useful but it may be buggy if some IM
has its own configuration to do the samething.

FIXME: Add test cases
```
