### PR TITLE
qt4 immodule: Add missing <clocale> include

### DIFF
--- a/qt4/immodule/plugin.cpp
+++ b/qt4/immodule/plugin.cpp
@@ -34,6 +34,8 @@
 
 #include "plugin.h"
 
+#include <clocale>
+
 #include <QtCore/QStringList>
 #ifdef Q_WS_X11
 # include <QtGui/QX11Info>


### PR DESCRIPTION
The commit in this pull request adds a missing locale.h include that was being relied upon implicit before. It made the build fail on platforms such as FreeBSD 10, which use libc++ instead of libstdc++ by default.
