### PR TITLE
Port to GAction and libpanel-applet 3.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -853,7 +853,7 @@ AC_ARG_ENABLE(gnome3-applet,
   [enable_gnome3_applet=yes])
 
 if test "x$enable_gnome3_applet" != xno; then
-  PKG_CHECK_MODULES(GNOME3_APPLET, libpanelapplet-4.0,
+  PKG_CHECK_MODULES(GNOME3_APPLET, libpanel-applet,
                     enable_gnome3_applet=yes, enable_gnome3_applet=no)
 fi
 

--- a/gtk3/toolbar/Makefile.am
+++ b/gtk3/toolbar/Makefile.am
@@ -7,7 +7,7 @@ helper_defs = -DUIM_DATADIR=\""$(datadir)/@PACKAGE@"\"
 
 libexec_PROGRAMS = uim-toolbar-applet-gnome3
 
-xmluidir = $(datadir)/gnome-panel/ui
+xmluidir = $(pkgdatadir)/ui
 xmlui_DATA = uim-applet-menu.xml
 
 uim_toolbar_applet_gnome3_LDADD = @GTK3_LIBS@ @GNOME3_APPLET_LIBS@ \

--- a/gtk3/toolbar/Makefile.am
+++ b/gtk3/toolbar/Makefile.am
@@ -1,4 +1,5 @@
 EXTRA_DIST = UimApplet.panel-applet.in.in \
+	     uim-applet-menu.xml \
 	     org.gnome.panel.applet.UimAppletFactory.service.in
 
 if GNOME3_APPLET
@@ -6,11 +7,15 @@ helper_defs = -DUIM_DATADIR=\""$(datadir)/@PACKAGE@"\"
 
 libexec_PROGRAMS = uim-toolbar-applet-gnome3
 
+xmluidir = $(datadir)/gnome-panel/ui
+xmlui_DATA = uim-applet-menu.xml
+
 uim_toolbar_applet_gnome3_LDADD = @GTK3_LIBS@ @GNOME3_APPLET_LIBS@ \
 			   $(top_builddir)/uim/libuim-scm.la \
 			   $(top_builddir)/uim/libuim.la \
 			   $(top_builddir)/uim/libuim-custom.la
 uim_toolbar_applet_gnome3_CPPFLAGS = \
+			   -DUIM_UIDATADIR="\"${xmluidir}\"" \
 			   $(helper_defs) -I$(top_srcdir) -I$(top_builddir)
 									 
 uim_toolbar_applet_gnome3_CFLAGS = @GTK3_CFLAGS@ @GNOME3_APPLET_CFLAGS@
@@ -18,7 +23,7 @@ uim_toolbar_applet_gnome3_CFLAGS = @GTK3_CFLAGS@ @GNOME3_APPLET_CFLAGS@
 uim_toolbar_applet_gnome3_SOURCES = applet-gnome3.c \
 			       ../../gtk2/toolbar/common-gtk.c
 
-appletdir = $(datadir)/gnome-panel/4.0/applets
+appletdir = $(datadir)/gnome-panel/5.0/applets
 applet_DATA = UimApplet.panel-applet
 applet_in_files = $(applet_DATA:=.in)
 applet_in_in_files = $(applet_in_files:=.in)

--- a/gtk3/toolbar/applet-gnome3.c
+++ b/gtk3/toolbar/applet-gnome3.c
@@ -44,83 +44,66 @@
 
 PanelApplet *uimapplet;
 
-static void exec_switcher(GtkAction *action, gpointer data);
-static void exec_pref(GtkAction *action, gpointer data);
-static void exec_dic(GtkAction *action, gpointer data);
-static void exec_pad(GtkAction *action, gpointer data);
-static void exec_hand(GtkAction *action, gpointer data);
-static void exec_help(GtkAction *action, gpointer data);
-static void display_about_dialog(GtkAction *action, gpointer data);
+static void exec_switcher(GSimpleAction *action, GVariant *parameter, gpointer data);
+static void exec_pref(GSimpleAction *action, GVariant *parameter, gpointer data);
+static void exec_dic(GSimpleAction *action, GVariant *parameter, gpointer data);
+static void exec_pad(GSimpleAction *action, GVariant *parameter, gpointer data);
+static void exec_hand(GSimpleAction *action, GVariant *parameter, gpointer data);
+static void exec_help(GSimpleAction *action, GVariant *parameter, gpointer data);
+static void display_about_dialog(GSimpleAction *action, GVariant *parameter, gpointer data);
 
 extern GtkWidget *uim_toolbar_applet_new(void);
 extern void uim_toolbar_launch_helper_application(const char *command);
 
-
-static const GtkActionEntry uim_menu_actions[] = {
-  {"Switcher", "im_switcher",
-    N_("Switch input method"), NULL, NULL, G_CALLBACK(exec_switcher)},
-  {"Pref", GTK_STOCK_PREFERENCES,
-    N_("Preference"), NULL, NULL, G_CALLBACK(exec_pref)},
-  {"Dic", "uim-dict",
-    N_("Japanese dictionary editor"), NULL, NULL, G_CALLBACK(exec_dic)},
-  {"Pad", GTK_STOCK_BOLD,
-    N_("Input pad"), NULL, NULL, G_CALLBACK(exec_pad)},
-  {"Hand", GTK_STOCK_EDIT,
-    N_("Handwriting input pad"), NULL, NULL, G_CALLBACK(exec_hand)},
-  {"Help", GTK_STOCK_HELP,
-    N_("Help"), NULL, NULL, G_CALLBACK(exec_help)},
-  {"About", GTK_STOCK_ABOUT,
-    N_("About"), NULL, NULL, G_CALLBACK(display_about_dialog)}
+static const GActionEntry uim_menu_actions[] = {
+  { "switcher", exec_switcher },
+  { "pref", exec_pref },
+  { "dic", exec_dic },
+  { "pad", exec_pad },
+  { "hand", exec_hand },
+  { "help", exec_help },
+  { "about", display_about_dialog }
 };
 
-static const char uim_menu_xml[] =
-  "<menuitem action=\"Switcher\"/>"
-  "<menuitem action=\"Pref\"/>"
-  "<menuitem action=\"Dic\"/>"
-  "<menuitem action=\"Pad\"/>"
-  "<menuitem action=\"Hand\"/>"
-  "<menuitem action=\"Help\"/>"
-  "<menuitem action=\"About\"/>";
-
 static void
-exec_switcher(GtkAction *action, gpointer data)
+exec_switcher(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   uim_toolbar_launch_helper_application("uim-im-switcher-gtk3");
 }
 
 static void
-exec_pref(GtkAction *action, gpointer data)
+exec_pref(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   uim_toolbar_launch_helper_application("uim-pref-gtk3");
 }
 
 static void
-exec_dic(GtkAction *action, gpointer data)
+exec_dic(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   uim_toolbar_launch_helper_application("uim-dict-gtk3");
 }
 
 static void
-exec_pad(GtkAction *action, gpointer data)
+exec_pad(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   uim_toolbar_launch_helper_application("uim-input-pad-ja-gtk3");
 }
 
 static void
-exec_hand(GtkAction *action, gpointer data)
+exec_hand(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   uim_toolbar_launch_helper_application("uim-tomoe-gtk");
 }
 
 static void
-exec_help(GtkAction *uic, gpointer data)
+exec_help(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   uim_toolbar_launch_helper_application("uim-help");
 }
 
 /* Just the about window... If it's already open, just focus it */
 static void
-display_about_dialog(GtkAction *action, gpointer data)
+display_about_dialog(GSimpleAction *action, GVariant *parameter, gpointer data)
 {
   GdkPixbuf *icon = NULL;
   const gchar *authors[] = {"uim Project", NULL};
@@ -149,7 +132,8 @@ static gboolean
 uim_applet_new(PanelApplet *applet, const gchar *iid, gpointer data)
 {
   GtkWidget *toolbar;
-  GtkActionGroup *action_group;
+  GSimpleActionGroup *action_group;
+  gchar *ui_path;
   
   uimapplet = applet;
 
@@ -164,11 +148,16 @@ uim_applet_new(PanelApplet *applet, const gchar *iid, gpointer data)
 
   gtk_widget_show_all(GTK_WIDGET(applet));
 
-  action_group = gtk_action_group_new("uim Applet Actions");
-  gtk_action_group_set_translation_domain(action_group, GETTEXT_PACKAGE);
-  gtk_action_group_add_actions(action_group, uim_menu_actions,
+  action_group = g_simple_action_group_new();
+  g_action_map_add_action_entries(G_ACTION_MAP (action_group), uim_menu_actions,
       G_N_ELEMENTS(uim_menu_actions), toolbar);
-  panel_applet_setup_menu(applet, uim_menu_xml, action_group);
+
+  ui_path = g_build_filename (UIM_UIDATADIR, "uim-applet-menu.xml", NULL);
+  panel_applet_setup_menu_from_file(applet, ui_path, action_group, GETTEXT_PACKAGE);
+  g_free(ui_path);
+
+  gtk_widget_insert_action_group (GTK_WIDGET (applet), "uim",
+                                  G_ACTION_GROUP (action_group));
 #if LIBPANEL_APPLET_HAVE_SET_BACKGROUND_WIDGET
   panel_applet_set_background_widget(applet, GTK_WIDGET(applet));
 #endif

--- a/gtk3/toolbar/uim-applet-menu.xml
+++ b/gtk3/toolbar/uim-applet-menu.xml
@@ -1,0 +1,30 @@
+<section>
+  <item>
+    <attribute name="label" translatable="yes">Switch input method</attribute>
+    <attribute name="action">uim.switcher</attribute>
+  </item>
+  <item>
+    <attribute name="label" translatable="yes">Preference</attribute>
+    <attribute name="action">uim.pref</attribute>
+  </item>
+  <item>
+    <attribute name="label" translatable="yes">Japanese dictionary editor</attribute>
+    <attribute name="action">uim.dic</attribute>
+  </item>
+  <item>
+    <attribute name="label" translatable="yes">Input pad</attribute>
+    <attribute name="action">uim.pad</attribute>
+  </item>
+  <item>
+    <attribute name="label" translatable="yes">Handwriting input pad</attribute>
+    <attribute name="action">uim.hand</attribute>
+  </item>
+  <item>
+    <attribute name="label" translatable="yes">Help</attribute>
+    <attribute name="action">uim.help</attribute>
+  </item>
+  <item>
+    <attribute name="label" translatable="yes">About</attribute>
+    <attribute name="action">uim.about</attribute>
+  </item>
+</section>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -16,6 +16,7 @@ gtk2/toolbar/applet-gnome.c
 gtk2/toolbar/common-gtk.c
 gtk2/toolbar/standalone-gtk.c
 gtk3/toolbar/applet-gnome3.c
+[type: gettext/glade]gtk3/toolbar/uim-applet-menu.xml
 qt3/chardict/bushuviewwidget.cpp
 qt3/chardict/qt.cpp
 qt3/chardict/unicodeviewwidget.cpp


### PR DESCRIPTION
Currently, uim does not build with gnome-panel (and libpanel-applet) 3.14, as the library API has changed significally. This PR attempts to fix it.

Note that I am not a user of uim and thus have not tested it properly.

References:

* https://wiki.gnome.org/HowDoI/GAction
* https://wiki.gnome.org/HowDoI/ApplicationMenu
* [gnome-panel 3.14 announce](https://mail.gnome.org/archives/gnome-announce-list/2014-October/msg00036.html)