### PR TITLE
plug leak to unclosed socket after exec() in client

### DIFF
--- a/uim/socket.c
+++ b/uim/socket.c
@@ -278,7 +278,10 @@ c_freeaddrinfo(uim_lisp addrinfo_)
 static uim_lisp
 c_socket(uim_lisp domain_, uim_lisp type_, uim_lisp protocol_)
 {
-  return MAKE_INT(socket(C_INT(domain_), C_INT(type_), C_INT(protocol_)));
+  int fd = socket(C_INT(domain_), C_INT(type_), C_INT(protocol_));
+  if (fd != -1)
+    fcntl(fd, F_SETFD, fcntl(fd, F_GETFD, 0) | FD_CLOEXEC);
+  return MAKE_INT(fd);
 }
 
 static uim_lisp

--- a/uim/uim-helper-client.c
+++ b/uim/uim-helper-client.c
@@ -89,6 +89,12 @@ int uim_helper_init_client_fd(void (*disconnect_cb)(void))
   server.sun_family = PF_UNIX;
   strlcpy(server.sun_path, path, sizeof(server.sun_path));
 
+#ifdef SOCK_CLOEXEC
+  /* linux-2.6.27+ variant that prevents racing on concurrent fork & exec in other thread */
+  fd = socket(PF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd == -1 && errno == EINVAL)
+    /* fallback to plain SOCK_TYPE on older kernel */
+#endif
   fd = socket(PF_UNIX, SOCK_STREAM, 0);
   if (fd < 0) {
     perror("fail to create socket");

--- a/uim/uim-helper-client.c
+++ b/uim/uim-helper-client.c
@@ -44,6 +44,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
@@ -93,6 +94,7 @@ int uim_helper_init_client_fd(void (*disconnect_cb)(void))
     perror("fail to create socket");
     goto error;
   }
+  fcntl(fd, F_SETFD, fcntl(fd, F_GETFD, 0) | FD_CLOEXEC);
   
 #ifdef LOCAL_CREDS /* for NetBSD */
   /* Set the socket to receive credentials on the next message */


### PR DESCRIPTION
forwarding from https://bugs.debian.org/787208 .
these patches are created by "Yuriy M. Kaminskiy" <yumkam@gmail.com>.

----
When uim client exec() to long-running process (e.g. iceweasel 
restarts), it leaks open socket to uim-helper-server, and by then 
uim-helper-server begins to constantly consume memory, as it cannot 
write to those sockets and have to infinitely buffer unsent messages to 
them:

```
strace -p `pidof uim-helper-server`|egrep '^(select|mremap)' ...
select(11, [0 1 3 4 5 6 7 9 10], [1], NULL, NULL) = 1 (in [0])
select(11, [0 1 3 4 5 6 7 9 10], [1 4 5 6 7 9 10], NULL, NULL) = 6 (out 
[4 5 6 7 9 10])
   note: here fd 1 points to unix-domain-socket to such iceweasel
   process, and it never returns "writeable" status; there are another
   socket to same iceweasel process {which was opened after restart},
   which is properly handled
select(11, [0 1 3 4 5 6 7 9 10], [1], NULL, NULL) = 1 (in [0])
select(11, [0 1 3 4 5 6 7 9 10], [1 4 5 6 7 9 10], NULL, NULL) = 6 (out 
[4 5 6 7 9 10])
select(11, [0 1 3 4 5 6 7 9 10], [1], NULL, NULL) = 1 (in [0])
select(11, [0 1 3 4 5 6 7 9 10], [1], NULL, NULL) = 1 (in [0])
mremap(0xb7318000, 1404928, 1409024, MREMAP_MAYMOVE) = 0xb7318000
   note: this is apparently reallocation of buffered messages for this
   socket; after few days, it already grown to 1.4M
select(11, [0 1 3 4 5 6 7 9 10], [1 4 5 6 7 9 10], NULL, NULL) = 6 (out 
[4 5 6 7 9 10])
select(11, [0 1 3 4 5 6 7 9 10], [1], NULL, NULL) = 1 (in [0])
select(11, [0 1 3 4 5 6 7 9 10], [1 4 5 6 7 9 10], NULL, NULL) = 6 (out 
[4 5 6 7 9 10])
select(11, [0 1 3 4 5 6 7 9 10], [1], NULL, NULL) = 1 (in [0])
```

Attached patch fixes this by setting CLOEXEC flag on all sockets (only
uim-helper-client.c part is definitely needed and safe; uim/socket.c 
part theoretically can break scm scripts that intentionally passes open 
socket fd to spawned processes [but AFAIK none of them does]).

Optional 2nd patch tries to use SOCK_CLOEXEC option, available in
linux-2.6.27+ (it would avoid race window between socket() and fcntl(), 
if another thread spawned process at the exact same time with socket 
creation), with fallback for older kernel.

This bug is also present in (all) older uim versions, and in the 
upstream master branch as well.

P.S. upstream: also, uim-helper-server could be improved a bit for 
better handling of "stuck client" scenario [aside from client bugs {e.g. 
uim-input-pad-ja is broken this way}, that could be stopped processes 
(^Z/kill -STOP), etc]. E.g. it could forget/merge older prop_update & 
focus_* messages [after reaching some size/last-writeable-time 
threshold, to avoid complication in common-case scenario].

P.P.S. BTW, uim-helper-client.c looks *extremely* fragile. If someone, 
somehow will call uim_helper_init_client twice, all hell will broke loose.