### PR TITLE
fix stuck messages to uim-input-pad-ja

### DIFF
--- a/gtk2/pad/ja.c
+++ b/gtk2/pad/ja.c
@@ -264,6 +264,7 @@ gchar *line[] = {
 };
 
 static int uim_fd = -1;
+static unsigned int read_tag;
 
 static GtkWidget *buttontable_create(char **table, int tablelen);
 static GtkWidget *create_hiragana_tab(void);
@@ -280,13 +281,34 @@ static GtkWidget *input_table_create(gchar *localename);
 static void       padbutton_clicked(GtkButton *button, gpointer user_data);
 
 
+static gboolean
+fd_read_cb(GIOChannel *channel, GIOCondition c, gpointer p)
+{
+  gchar *msg;
+  int fd = g_io_channel_unix_get_fd(channel);
+
+  uim_helper_read_proc(fd);
+
+  while ((msg = uim_helper_get_message())) {
+    /* do nothing */
+    free(msg);
+  }
+
+  return TRUE;
+}
+
 static void
 check_helper_connection(void)
 {
   if (uim_fd < 0) {
     uim_fd = uim_helper_init_client_fd(helper_disconnect_cb);
-    if (uim_fd < 0)
-      return;
+    if (uim_fd >= 0) {
+      GIOChannel *channel;
+      channel = g_io_channel_unix_new(uim_fd);
+      read_tag = g_io_add_watch(channel, G_IO_IN | G_IO_HUP | G_IO_ERR,
+				fd_read_cb, NULL);
+      g_io_channel_unref(channel);
+    }
   }
 }
 
@@ -294,6 +316,7 @@ static void
 helper_disconnect_cb(void)
 {
   uim_fd = -1;
+  g_source_remove(read_tag);
 }
 
 static void


### PR DESCRIPTION
forwarding from https://bugs.debian.org/787824
this patches are created by "Yuriy M. Kaminskiy" <yumkam@gmail.com>.

----

When uim-input-pad-ja (both gtk2 and gtk3 versions) is running for a 
long time, it triggers growing memory consumption in uim-helper-server, 
as it opens socket to uim-helper-server, but fails to process incoming 
messages (it only uses this socket to write new messages).

Attached patch tries to fix this by adding dummy read handler (it is not
possible to half-close connection, as uim-helper-server will close
connection in this case).
Note: this bug also affects upstream master branch and many/all older 
versions.