### PR TITLE
fix CMake Error not found QT_QT_INCLUDE_DIR when specify both --with-qt4 and --with-qt5.

### DIFF
--- a/qt4/toolbar/CMakeLists.txt
+++ b/qt4/toolbar/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(plasma-uim)
 
+find_package(Qt4)
 find_package(KDE4 REQUIRED)
 include(KDE4Defaults)
 


### PR DESCRIPTION
if specify both --with-qt4 and --with-qt5 at configure,
it causes CMake Error not found QT_QT_INCLUDE_DIR.
there is no side effect outside of Qt5 branch.
