### PR TITLE
fix "empty" typo

### DIFF
--- a/gtk2/dict/word-win-gtk.c
+++ b/gtk2/dict/word-win-gtk.c
@@ -631,7 +631,7 @@ word_window_validate_values(WordWindow *window)
 				    GTK_DIALOG_MODAL,
 				    GTK_MESSAGE_ERROR,
 				    GTK_BUTTONS_CLOSE,
-				    "%s", _("Phonetic is emtpy!"));
+				    "%s", _("Phonetic is empty!"));
     g_signal_connect(G_OBJECT(dialog), "response",
 		     G_CALLBACK(message_dialog_response_cb), window);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(window));
@@ -646,7 +646,7 @@ word_window_validate_values(WordWindow *window)
 				    GTK_DIALOG_MODAL,
 				    GTK_MESSAGE_ERROR,
 				    GTK_BUTTONS_CLOSE,
-				    "%s", _("Literal is emtpy!"));
+				    "%s", _("Literal is empty!"));
     g_signal_connect(G_OBJECT(dialog), "response",
 		     G_CALLBACK(message_dialog_response_cb), window);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(window));
@@ -664,7 +664,7 @@ word_window_validate_values(WordWindow *window)
 				    GTK_DIALOG_MODAL,
 				    GTK_MESSAGE_ERROR,
 				    GTK_BUTTONS_CLOSE,
-				    "%s", _("Part of speech is emtpy!"));
+				    "%s", _("Part of speech is empty!"));
     g_signal_connect(G_OBJECT(dialog), "response",
 		     G_CALLBACK(message_dialog_response_cb), window);
     gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(window));

--- a/po/fr.po
+++ b/po/fr.po
@@ -289,15 +289,15 @@ msgid "Word registration succeded."
 msgstr ""
 
 #: ../gtk2/dict/word-win-gtk.c:546
-msgid "Phonetic is emtpy!"
+msgid "Phonetic is empty!"
 msgstr ""
 
 #: ../gtk2/dict/word-win-gtk.c:561
-msgid "Literal is emtpy!"
+msgid "Literal is empty!"
 msgstr ""
 
 #: ../gtk2/dict/word-win-gtk.c:579
-msgid "Part of speech is emtpy!"
+msgid "Part of speech is empty!"
 msgstr ""
 
 #: ../gtk2/pad/ja.c:491

--- a/po/ja.po
+++ b/po/ja.po
@@ -381,15 +381,15 @@ msgid "Word registration succeded."
 msgstr "単語の登録に成功しました。"
 
 #: ../gtk2/dict/word-win-gtk.c:546
-msgid "Phonetic is emtpy!"
+msgid "Phonetic is empty!"
 msgstr "読み方が入力されていません！"
 
 #: ../gtk2/dict/word-win-gtk.c:561
-msgid "Literal is emtpy!"
+msgid "Literal is empty!"
 msgstr "書き方が入力されていません！"
 
 #: ../gtk2/dict/word-win-gtk.c:579
-msgid "Part of speech is emtpy!"
+msgid "Part of speech is empty!"
 msgstr "品詞が入力されていません！"
 
 #: ../gtk2/pad/ja.c:491

--- a/po/ko.po
+++ b/po/ko.po
@@ -290,15 +290,15 @@ msgid "Word registration succeded."
 msgstr ""
 
 #: ../gtk2/dict/word-win-gtk.c:546
-msgid "Phonetic is emtpy!"
+msgid "Phonetic is empty!"
 msgstr ""
 
 #: ../gtk2/dict/word-win-gtk.c:561
-msgid "Literal is emtpy!"
+msgid "Literal is empty!"
 msgstr ""
 
 #: ../gtk2/dict/word-win-gtk.c:579
-msgid "Part of speech is emtpy!"
+msgid "Part of speech is empty!"
 msgstr ""
 
 #: ../gtk2/pad/ja.c:491


### PR DESCRIPTION
They are found by Debian Lintian: spelling-error-in-binary