### PR TITLE
fix "occurred" typo

### DIFF
--- a/ChangeLog.old
+++ b/ChangeLog.old
@@ -3803,7 +3803,7 @@
 2004-09-28 kzk <mover@hct.zaq.ne.jp>
 	
 	* scm/prime.scm
-	  - fix unbound symbol problem occured at r1304
+	  - fix unbound symbol problem occurred at r1304
 	
 2004-09-28 Masahito Omote <omote@utyuuzin.net>
 	

--- a/ChangeLog.old.2
+++ b/ChangeLog.old.2
@@ -35028,7 +35028,7 @@
 2005-08-21 TOKUNAGA Hiroyuki <tkng@xem.jp>
 
     * Renamed scm/PY.scm as scm/PY-old.scm. This file is not yet removed as a measure
-      when problem occured, will be removed until 0.5.1.
+      when problem occurred, will be removed until 0.5.1.
 
 2005-08-21 Etsushi Kato <ek.kato@gmail.com>
 
@@ -35655,7 +35655,7 @@
      -(caret_state_indicator_update): Added NULL check for str.
     
     * gtk/gtk-im-uim.c:
-     -(im_uim_commit_string): Update caret-state-indicator position when commit event occured.
+     -(im_uim_commit_string): Update caret-state-indicator position when commit event occurred.
      -(update_prop_label_cb): Call caret_state_indicator_set_timeout to set timeout.
 
 2005-08-05 TOKUNAGA Hiroyuki <tkng@xem.jp>

--- a/doc/ENV
+++ b/doc/ENV
@@ -31,7 +31,7 @@ libuim accepts some enviroment variables mainly for debugging purpose.
 
   This variable takes a number as a value. 0-10 can be specified. If
   LIBUIM_VERBOSE is greater than or equal to 5, uim shows backtrace
-  when error occured if --enable-backtrace is set by configure.
+  when error occurred if --enable-backtrace is set by configure.
 
 - LIBUIM_VANILLA
 

--- a/doc/api-doc/uim-devel.db
+++ b/doc/api-doc/uim-devel.db
@@ -441,7 +441,7 @@
         <listitem>
           <para>
 	    This variable takes a number as a value. Range of number is 0-10. If LIBUIM_VERBOSE is
-	    greater than or equal 5, uim shows backtrace when error occured.
+	    greater than or equal 5, uim shows backtrace when error occurred.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/xim/main.cpp
+++ b/xim/main.cpp
@@ -243,7 +243,7 @@ X_ErrorHandler(Display *d, XErrorEvent *e)
 	if (e->error_code) {
 	    char buf[64];
 	    XGetErrorText(d, e->error_code, buf, 63);
-	    printf("X error occured. %s\n", buf);
+	    printf("X error occurred. %s\n", buf);
 	}
     }
 


### PR DESCRIPTION
They are found by Debian Lintian: spelling-error-in-binary