### PR TITLE
Fix candidate window problem

### DIFF
--- a/gtk2/immodule/uim-cand-win-gtk.c
+++ b/gtk2/immodule/uim-cand-win-gtk.c
@@ -225,7 +225,7 @@ uim_cand_win_gtk_init (UIMCandWinGtk *cwin)
 
   gtk_widget_set_size_request(cwin->num_label, DEFAULT_MIN_WINDOW_WIDTH, -1);
   gtk_window_set_default_size(GTK_WINDOW(cwin), DEFAULT_MIN_WINDOW_WIDTH, -1);
-  gtk_window_set_resizable(GTK_WINDOW(cwin), FALSE);
+  gtk_window_set_resizable(GTK_WINDOW(cwin), TRUE);
 }
 
 static void


### PR DESCRIPTION
 I fixed the problem that the candidate windows is not shown in GTK3  applications on Fedora 22.