### PR TITLE
Fixed the IID definition to work with Qt5.5.

### DIFF
--- a/qt4/immodule/plugin.h
+++ b/qt4/immodule/plugin.h
@@ -54,7 +54,7 @@ class UimInputContextPlugin : public QPlatformInputContextPlugin
     Q_OBJECT
 #if QT_VERSION >= 0x050000
     Q_PLUGIN_METADATA(IID
-        "org.qt-project.Qt.QPlatformInputContextFactoryInterface"
+        QPlatformInputContextFactoryInterface_iid
         FILE "../../qt5/immodule/uim.json")
 #endif
 public:


### PR DESCRIPTION
Qt5.5 does not load libuimplatforminputcontextplugin.so that has IID `"org.qt-project.Qt.QPlatformInputContextFactoryInterface"` but works with IID `"org.qt-project.Qt.QPlatformInputContextFactoryInterface.5.1"`.
It works fine using `QPlatformInputContextFactoryInterface_iid` instead of fixed string. 

This issue is same as fcitx's issue below:
https://github.com/fcitx/fcitx-qt5/issues/6