### PR TITLE
fix cannot select candidate on GTK3 application, closes #77

### DIFF
--- a/gtk2/immodule/uim-cand-win-vertical-gtk.c
+++ b/gtk2/immodule/uim-cand-win-vertical-gtk.c
@@ -206,16 +206,19 @@ tree_selection_change(GtkTreeSelection *selection,
   g_return_val_if_fail(indicies, TRUE);
   idx = *indicies + cwin->display_limit * cwin->page_index;
 
+  if (path_currently_selected && cwin->candidate_index >= 0) {
+    /* if emit "index-changed" here and IM deactivates this candwin,
+     * activates new candwin and selects a candidate on new candwin
+     * from index-changed callback, SEGV occurs in gtk because gtk tries to
+     * select on old candwin after return of this tree_selection_change().
+     * To avoid SEGV, instead of emitting before selection change by gtk,
+     * emit after selection changed by gtk. */
+    cwin->index_changed = TRUE;
+  }
+
   if (!path_currently_selected && cwin->candidate_index != idx) {
     if (cwin->candidate_index >= 0) {
       cwin->candidate_index = idx;
-      /* if emit "index-changed" here and IM deactivates this candwin,
-       * activates new candwin and selects a candidate on new candwin
-       * from index-changed callback, SEGV occurs in gtk because gtk tries to
-       * select on old candwin after return of this tree_selection_change().
-       * To avoid SEGV, instead of emitting before selection change by gtk,
-       * emit after selection changed by gtk. */
-      cwin->index_changed = TRUE;
     }
 
     uim_cand_win_gtk_update_label(cwin);


### PR DESCRIPTION
created-by: NaofumiHonda

----
Around the line 209 in gtk2/immodule/uim-cand-win-vertical-gtk.c, the code assumes that the conditions path_currently_selected == false and cwin->candidate_index != idx only hold for the case that a candidate is selected by a mouse click.
Surely this assumption is true for gkt2 case. However, in gtk3 case, the same conditions also hold when the candidate window becomes hidden by changing a target word, which causes a wired phenomenon.
Therefore we need to consider the latter case also and it has been done in the attached patch.

Of course, this patch respects the commitment bc40465 for SEGV.