### PR TITLE
Fix qt5 candwin infinite loop, closes#30

### DIFF
--- a/qt4/candwin/abstractcandidatewindow.cpp
+++ b/qt4/candwin/abstractcandidatewindow.cpp
@@ -50,7 +50,7 @@ const Qt::WindowFlags candidateFlag = (Qt::Window
                                         | Qt::WindowStaysOnTopHint
                                         | Qt::FramelessWindowHint
                                         | Qt::Tool
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
                                         | Qt::X11BypassWindowManagerHint
 #endif
                                  );

--- a/qt4/candwin/subwindow.cpp
+++ b/qt4/candwin/subwindow.cpp
@@ -51,7 +51,7 @@ const Qt::WindowFlags subwindowFlag = (Qt::Window
                                         | Qt::WindowStaysOnTopHint
                                         | Qt::FramelessWindowHint
                                         | Qt::Tool
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
                                         | Qt::X11BypassWindowManagerHint
 #endif
                                 );

--- a/qt4/candwin/ximcandidatewindow.cpp
+++ b/qt4/candwin/ximcandidatewindow.cpp
@@ -73,7 +73,7 @@ const Qt::WindowFlags candidateFlag = (Qt::Window
                                         | Qt::WindowStaysOnTopHint
                                         | Qt::FramelessWindowHint
                                         | Qt::Tool
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
                                         | Qt::X11BypassWindowManagerHint
 #endif
                                 );

--- a/qt4/immodule/candidatewindowproxy.cpp
+++ b/qt4/immodule/candidatewindowproxy.cpp
@@ -297,7 +297,6 @@ void CandidateWindowProxy::initializeProcess()
     if (process->state() != QProcess::NotRunning) {
         return;
     }
-/*    process->close(); */
     QString style = candidateWindowStyle();
     qputenv("__UIM_CANDWIN_CALLED", QByteArray("STARTED"));
 #if QT_VERSION < 0x050000

--- a/qt4/immodule/candidatewindowproxy.cpp
+++ b/qt4/immodule/candidatewindowproxy.cpp
@@ -297,8 +297,9 @@ void CandidateWindowProxy::initializeProcess()
     if (process->state() != QProcess::NotRunning) {
         return;
     }
-    process->close();
+/*    process->close(); */
     QString style = candidateWindowStyle();
+    qputenv("__UIM_CANDWIN_CALLED", QByteArray("STARTED"));
 #if QT_VERSION < 0x050000
     process->start(UIM_LIBEXECDIR "/uim-candwin-qt4", QStringList() << style);
 #else
@@ -556,6 +557,8 @@ void CandidateWindowProxy::preparePageCandidates(int page)
 
 void CandidateWindowProxy::setFocusWidget()
 {
+    if (QApplication::focusWidget() == NULL)
+	return;
     window = QApplication::focusWidget()->window();
     window->installEventFilter(this);
 }

--- a/qt4/immodule/plugin.cpp
+++ b/qt4/immodule/plugin.cpp
@@ -96,6 +96,9 @@ QInputContext *UimInputContextPlugin::create( const QString & key )
 QPlatformInputContext *UimInputContextPlugin::create( const QString & key, const QStringList & paramList )
 #endif
 {
+    if (qgetenv("__UIM_CANDWIN_CALLED") == QByteArray("STARTED"))
+	return NULL;
+
 #if QT_VERSION >= 0x050000
     Q_UNUSED(paramList);
 #endif

--- a/qt4/immodule/qtextutil.cpp
+++ b/qt4/immodule/qtextutil.cpp
@@ -143,7 +143,7 @@ QUimTextUtil::acquirePrimaryText( enum UTextOrigin origin,
                                   char **former, char **latter )
 {
     int err;
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
     mWidget = QApplication::focusWidget();
 #else
     return -1;
@@ -551,7 +551,7 @@ QUimTextUtil::acquireSelectionText( enum UTextOrigin origin,
                                     char **former, char **latter )
 {
     int err;
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
     mWidget = QApplication::focusWidget();
 #else
     return -1;
@@ -821,7 +821,7 @@ QUimTextUtil::deletePrimaryText( enum UTextOrigin origin, int former_req_len,
                                  int latter_req_len )
 {
     int err;
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
     mWidget = QApplication::focusWidget();
 #else
     return -1;
@@ -1130,7 +1130,7 @@ QUimTextUtil::deleteSelectionText( enum UTextOrigin origin,
                                    int former_req_len, int latter_req_len )
 {
     int err;
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
     mWidget = QApplication::focusWidget();
 #else
     return -1;

--- a/qt4/immodule/quiminputcontext_compose.cpp
+++ b/qt4/immodule/quiminputcontext_compose.cpp
@@ -526,7 +526,7 @@ modmask(char *name)
     return(mask);
 }
 
-#ifdef Q_WS_X11
+#if defined(Q_WS_X11)
 int
 QUimInputContext::TransFileName(char *transname, const char *name, size_t len)
 {

--- a/qt5/immodule/quimplatforminputcontext.cpp
+++ b/qt5/immodule/quimplatforminputcontext.cpp
@@ -224,7 +224,7 @@ bool QUimPlatformInputContext::filterEvent(const QEvent *event)
         modifier |= UMod_Control;
     if (keyevent->modifiers() & Qt::AltModifier)
         modifier |= UMod_Alt;
-#if defined(Q_WS_X11)
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
     if (keyevent->modifiers() & Qt::MetaModifier)
         modifier |= UMod_Meta;
 #endif
@@ -338,7 +338,7 @@ bool QUimPlatformInputContext::filterEvent(const QEvent *event)
                         modifier &= ~UMod_Alt;
                     break;
                 case Qt::Key_Meta: key = UKey_Meta_key;
-#ifdef Q_WS_X11
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX)
                     if (type == QEvent::KeyPress)
                         modifier &= ~UMod_Meta;
 #endif

--- a/qt5/immodule/quimplatforminputcontext.h
+++ b/qt5/immodule/quimplatforminputcontext.h
@@ -76,6 +76,7 @@ public:
     virtual void reset();
     virtual void showInputPanel();
     virtual void update(Qt::InputMethodQueries);
+    virtual void setFocusObject(QObject *object);
 
     uim_context uimContext() { return m_uc; }
 
@@ -99,7 +100,6 @@ public:
 private:
     uim_context createUimContext(const char *imname);
     void createCandidateWindow();
-    void setFocusObject(QObject *object);
     void setFocus();
     void unsetFocus();
 


### PR DESCRIPTION
Created-by: NaofumiHonda

----
The reason of the issue is that: the uim-candwin-qt5 also load the uim-plugin, and the loaded plugin again executes uim-candwin-qt5, which causes infinite loops! So it suffices to block this recursive execution.