### PR TITLE
fix global variablel uim_fd, closes #87

### DIFF
--- a/gtk2/immodule/gtk-im-uim.c
+++ b/gtk2/immodule/gtk-im-uim.c
@@ -1283,12 +1283,13 @@ helper_read_cb(GIOChannel *channel, GIOCondition c, gpointer p)
 }
 
 static void
-check_helper_connection()
+check_helper_connection(uim_context uc)
 {
   if (im_uim_fd < 0) {
     im_uim_fd = uim_helper_init_client_fd(helper_disconnect_cb);
     if (im_uim_fd >= 0) {
       GIOChannel *channel;
+      uim_set_uim_fd(uc, im_uim_fd);
       channel = g_io_channel_unix_new(im_uim_fd);
       read_tag = g_io_add_watch(channel, G_IO_IN | G_IO_HUP | G_IO_ERR,
 				helper_read_cb, NULL);
@@ -1416,7 +1417,7 @@ im_uim_focus_in(GtkIMContext *ic)
   update_cur_toplevel(uic);
 #endif
 
-  check_helper_connection();
+  check_helper_connection(uic->uc);
   uim_helper_client_focus_in(uic->uc);
   uim_prop_list_update(uic->uc);
 
@@ -1447,7 +1448,7 @@ im_uim_focus_out(GtkIMContext *ic)
 
   uim_focus_out_context(uic->uc);
 
-  check_helper_connection();
+  check_helper_connection(uic->uc);
   uim_helper_client_focus_out(uic->uc);
 
   if (uic->cwin)
@@ -1681,7 +1682,7 @@ im_module_create(const gchar *context_id)
     return NULL;
   }
 
-  check_helper_connection();
+  check_helper_connection(uic->uc);
 
   uim_set_preedit_cb(uic->uc, clear_cb, pushback_cb, update_cb);
   uim_set_prop_list_update_cb(uic->uc, update_prop_list_cb);

--- a/qt4/immodule/qhelpermanager.cpp
+++ b/qt4/immodule/qhelpermanager.cpp
@@ -78,7 +78,7 @@ QUimHelperManager::~QUimHelperManager()
         uim_helper_close_client_fd( im_uim_fd );
 }
 
-void QUimHelperManager::checkHelperConnection()
+void QUimHelperManager::checkHelperConnection(uim_context uc)
 {
     if ( im_uim_fd < 0 )
     {
@@ -89,6 +89,7 @@ void QUimHelperManager::checkHelperConnection()
             notifier = new QSocketNotifier( im_uim_fd, QSocketNotifier::Read );
             connect( notifier, SIGNAL( activated( int ) ),
                               this, SLOT( slotStdinActivated() ) );
+            uim_set_uim_fd(uc, im_uim_fd);
         }
     }
 }

--- a/qt4/immodule/qhelpermanager.h
+++ b/qt4/immodule/qhelpermanager.h
@@ -34,6 +34,7 @@ SUCH DAMAGE.
 #define UIM_QT4_IMMODULE_QHELPERMANAGER_H
 
 #include <QtCore/QObject>
+#include "uim/uim.h"
 
 class QString;
 
@@ -45,7 +46,7 @@ public:
     explicit QUimHelperManager( QObject * parent = 0 );
     ~QUimHelperManager();
 
-    void checkHelperConnection();
+    void checkHelperConnection(uim_context);
     void parseHelperStr( const QString &str );
     void parseHelperStrImChange( const QString &str );
 

--- a/qt4/immodule/quiminputcontext.cpp
+++ b/qt4/immodule/quiminputcontext.cpp
@@ -149,8 +149,7 @@ uim_context QUimInputContext::createUimContext( const char *imname )
                                          0,
                                          QUimInputContext::commit_cb );
 
-    m_HelperManager->checkHelperConnection();
-
+    m_HelperManager->checkHelperConnection(uc);
     /**/
 
     uim_set_preedit_cb( uc, QUimInputContext::clear_cb,
@@ -400,7 +399,7 @@ void QUimInputContext::setFocus()
     if ( candwinIsActive )
         proxy->popup();
 
-    m_HelperManager->checkHelperConnection();
+    m_HelperManager->checkHelperConnection(m_uc);
 
     uim_helper_client_focus_in( m_uc );
     uim_prop_list_update( m_uc );
@@ -421,7 +420,7 @@ void QUimInputContext::unsetFocus()
     proxy->hide();
     m_indicator->hide();
 
-    m_HelperManager->checkHelperConnection();
+    m_HelperManager->checkHelperConnection(m_uc);
 
     uim_helper_client_focus_out( m_uc );
 }

--- a/qt5/immodule/quimplatforminputcontext.cpp
+++ b/qt5/immodule/quimplatforminputcontext.cpp
@@ -117,7 +117,7 @@ uim_context QUimPlatformInputContext::createUimContext(const char *imname)
     uim_context uc = uim_create_context(this, "UTF-8", 0, imname, 0,
             QUimPlatformInputContext::commit_cb);
 
-    m_helperManager->checkHelperConnection();
+    m_helperManager->checkHelperConnection(uc);
 
     /**/
 
@@ -171,7 +171,7 @@ void QUimPlatformInputContext::setFocus()
     if (candwinIsActive)
         proxy->popup();
 
-    m_helperManager->checkHelperConnection();
+    m_helperManager->checkHelperConnection(m_uc);
 
     uim_helper_client_focus_in(m_uc);
     uim_prop_list_update(m_uc);
@@ -190,7 +190,7 @@ void QUimPlatformInputContext::unsetFocus()
 
     proxy->hide();
 
-    m_helperManager->checkHelperConnection();
+    m_helperManager->checkHelperConnection(m_uc);
 
     uim_helper_client_focus_out(m_uc);
 }

--- a/uim/uim-helper-client.c
+++ b/uim/uim-helper-client.c
@@ -169,14 +169,14 @@ void
 uim_helper_client_focus_in(uim_context uc)
 {
   if (uc)
-    uim_helper_send_message(uim_fd, "focus_in\n");
+    uim_helper_send_message(uc->uim_fd != -1 ? uc->uim_fd : uim_fd, "focus_in\n");
 }
 
 void
 uim_helper_client_focus_out(uim_context uc)
 {
   if (uc)
-    uim_helper_send_message(uim_fd, "focus_out\n");
+    uim_helper_send_message(uc->uim_fd != -1 ? uc->uim_fd : uim_fd, "focus_out\n");
 }
 
 void

--- a/uim/uim-helper.c
+++ b/uim/uim-helper.c
@@ -331,6 +331,18 @@ uim_helper_buffer_get_message(char *buf)
   return msg;
 }
 
+void
+uim_set_uim_fd(uim_context uc, int fd)
+{
+  uc->uim_fd = fd;
+}
+
+void
+uim_unset_uim_fd(uim_context uc)
+{
+  uc->uim_fd = -1;
+}
+
 /* Public API for uim_issetugid(). */
 /* TODO: should be renamed to uim_helper_issetugid() */
 uim_bool

--- a/uim/uim-helper.h
+++ b/uim/uim-helper.h
@@ -59,6 +59,9 @@ char *uim_helper_buffer_append(char *buf,
 void uim_helper_buffer_shift(char *buf, int count);
 char *uim_helper_buffer_get_message(char *buf);
 
+void uim_set_uim_fd(uim_context, int);
+void uim_unset_uim_fd(uim_context);
+
 uim_bool
 uim_helper_is_setugid(void);
 

--- a/uim/uim-internal.h
+++ b/uim/uim-internal.h
@@ -94,6 +94,9 @@ struct uim_context_ {
   /* legacy 'property' API */
   char *propstr;
 
+  /* helper system */
+  int uim_fd;
+
   /* commit */
   void (*commit_cb)(void *ptr, const char *str);
   /* preedit */

--- a/uim/uim.c
+++ b/uim/uim.c
@@ -220,6 +220,9 @@ uim_create_context(void *ptr,
   uc = uim_malloc(sizeof(*uc));
   memset(uc, 0, sizeof(*uc));
 
+  /* helper system */
+  uc->uim_fd = -1;
+
   /* encoding handlings */
   if (!enc)
     enc = "UTF-8";


### PR DESCRIPTION
* uim/uim-internal.h, uim/uim.c : struct uim_context_ has uim_fd for helper system.
* uim/uim-helper.c, uim/uim-helper.h
    * (uim_set_uim_fd): new function
    * (uim_unset_uim_fd): new function
* gtk2/immodule/gtk-im-uim.c (check_helper_connection) : add uim_context arg.
* qt4/immodule/qhelpermanager.cpp (QUimHelperManager::checkHelperConnection) : add uim_context arg.