### PR TITLE
Make the GNOME Panel applet compatible with libpanel-applet2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -861,6 +861,14 @@ fi
 
 AM_CONDITIONAL(GNOME3_APPLET, test "x$enable_gnome3_applet" = xyes)
 
+if test "x$enable_gnome3_applet" = xyes; then
+  AC_ARG_WITH([libpanel-applet-dir], [], [LIBPANEL_APPLET_DIR=$withval], [LIBPANEL_APPLET_DIR=""])
+  if test "$LIBPANEL_APPLET_DIR" == ""; then
+    LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=libpanel_applet_dir libpanel-applet`
+  fi
+  AC_SUBST(LIBPANEL_APPLET_DIR)
+fi
+
 AC_ARG_ENABLE(debug,
   AC_HELP_STRING([--enable-debug],
     [enable debugging]),

--- a/gtk3/toolbar/Makefile.am
+++ b/gtk3/toolbar/Makefile.am
@@ -1,51 +1,45 @@
 EXTRA_DIST = UimApplet.panel-applet.in.in \
-	     uim-applet-menu.xml \
-	     org.gnome.panel.applet.UimAppletFactory.service.in
+	     uim-applet-menu.xml
 
 if GNOME3_APPLET
 helper_defs = -DUIM_DATADIR=\""$(datadir)/@PACKAGE@"\"
 
-libexec_PROGRAMS = uim-toolbar-applet-gnome3
+uim_toolbar_applet_gnome3_libdir = $(pkglibdir)
+uim_toolbar_applet_gnome3_lib_LTLIBRARIES = libuim-toolbar-applet-gnome3.la
 
 xmluidir = $(pkgdatadir)/ui
 xmlui_DATA = uim-applet-menu.xml
 
-uim_toolbar_applet_gnome3_LDADD = @GTK3_LIBS@ @GNOME3_APPLET_LIBS@ \
+libuim_toolbar_applet_gnome3_la_LIBADD = @GTK3_LIBS@ @GNOME3_APPLET_LIBS@ \
 			   $(top_builddir)/uim/libuim-scm.la \
 			   $(top_builddir)/uim/libuim.la \
 			   $(top_builddir)/uim/libuim-custom.la
-uim_toolbar_applet_gnome3_CPPFLAGS = \
+libuim_toolbar_applet_gnome3_la_CPPFLAGS = \
 			   -DUIM_UIDATADIR="\"${xmluidir}\"" \
 			   $(helper_defs) -I$(top_srcdir) -I$(top_builddir)
-									 
-uim_toolbar_applet_gnome3_CFLAGS = @GTK3_CFLAGS@ @GNOME3_APPLET_CFLAGS@
 
-uim_toolbar_applet_gnome3_SOURCES = applet-gnome3.c \
+libuim_toolbar_applet_gnome3_la_CFLAGS = @GTK3_CFLAGS@ @GNOME3_APPLET_CFLAGS@
+
+libuim_toolbar_applet_gnome3_la_SOURCES = applet-gnome3.c \
 			       ../../gtk2/toolbar/common-gtk.c
 
-appletdir = $(datadir)/gnome-panel/5.0/applets
+APPLET_LOCATION = $(pkglibdir)/libuim-toolbar-applet-gnome3.so
+
+appletdir = $(LIBPANEL_APPLET_DIR)
 applet_DATA = UimApplet.panel-applet
 applet_in_files = $(applet_DATA:=.in)
 applet_in_in_files = $(applet_in_files:=.in)
 
 $(applet_in_files): $(applet_in_in_files) Makefile
-	$(SED) s,@LIBEXECDIR@,$(libexecdir),g <$< >$@.tmp
+	$(SED) s,@APPLET_LOCATION@,$(APPLET_LOCATION),g <$< >$@.tmp
 	$(SED) s,@UIM_PIXMAPSDIR@,$(uim_pixmapsdir),g <$@.tmp >$@
 
 po_files = $(wildcard $(top_srcdir)/po/*.po)
 $(applet_DATA): $(applet_in_files) $(INTLTOOL_MERGE) $(po_files)
 	LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< $@ 
 
-servicedir = $(datadir)/dbus-1/services
-service_DATA = org.gnome.panel.applet.UimAppletFactory.service
-service_in_files = $(service_DATA:=.in)
-
-$(service_DATA): $(service_in_files) Makefile
-	sed s,@LIBEXECDIR@,$(libexecdir),g <$< >$@
-
 DISTCLEANFILES = UimApplet.panel-applet.in UimApplet.panel-applet \
-		 UimApplet.panel-applet.in.tmp \
-		 org.gnome.panel.applet.UimAppletFactory.service
+		 UimApplet.panel-applet.in.tmp
 endif
 
 if GTK3

--- a/gtk3/toolbar/UimApplet.panel-applet.in.in
+++ b/gtk3/toolbar/UimApplet.panel-applet.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=UimAppletFactory
-Location=@LIBEXECDIR@/uim-toolbar-applet-gnome3
+InProcess=true
+Location=@APPLET_LOCATION@
 _Name=uim Applet Factory
 _Description=uim applet factory
 

--- a/gtk3/toolbar/applet-gnome3.c
+++ b/gtk3/toolbar/applet-gnome3.c
@@ -168,7 +168,7 @@ uim_applet_new(PanelApplet *applet, const gchar *iid, gpointer data)
 
 
 
-PANEL_APPLET_OUT_PROCESS_FACTORY("UimAppletFactory",
+PANEL_APPLET_IN_PROCESS_FACTORY("UimAppletFactory",
                             PANEL_TYPE_APPLET,
                             (PanelAppletFactoryCallback)uim_applet_new,
                             NULL)

--- a/gtk3/toolbar/org.gnome.panel.applet.UimAppletFactory.service.in
+++ b/gtk3/toolbar/org.gnome.panel.applet.UimAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.gnome.panel.applet.UimAppletFactory
-Exec=@LIBEXECDIR@/uim-toolbar-applet-gnome3


### PR DESCRIPTION
GNOME Panel 3.22 was released recently with the new version of library, libpanel-applet2. There are some changes required to make uim build/work with this new version.

* Port from out-of-process applet to in-process applet.
* Get the applets directory from pkg-config instead of using the hard-coded path.

See [this link] for details. This code should still work with the previous versions of GNOME Panel (3.14+).

On Debian, the new `libpanel-applet-dev` package is available in experimental.

[this link]: https://mail.gnome.org/archives/gnome-flashback-list/2016-July/msg00000.html