### PR TITLE
Do not use private qt_plugin.prf in quimplatforminputcontextplugin.pro

### DIFF
--- a/qt5/immodule/quimplatforminputcontextplugin.pro.in
+++ b/qt5/immodule/quimplatforminputcontextplugin.pro.in
@@ -1,7 +1,7 @@
 include(../../qt4/common.pro)
 
-PLUGIN_TYPE = platforminputcontexts
-load(qt_plugin)
+TEMPLATE = lib
+CONFIG += plugin
 
 # to include util.h and for quimplatforminputcontext.cpp
 INCLUDEPATH += @srcdir@/../../qt4/candwin \


### PR DESCRIPTION
When using it, we get the following error when running qmake on Ubuntu 17.10 with Qt 5.9.0 ([full build log](https://launchpadlibrarian.net/324642605/buildlog_ubuntu-artful-amd64.uim_1%3A1.8.6+gh20161003.0.d63dadd-2ubuntu3~ppa1_BUILDING.txt.gz)):

    Project ERROR: Could not find feature reduce_exports.

The Qt developers say in [QTBUG-58150](https://bugreports.qt.io/browse/QTBUG-58150):

> this file [qt_plugin.prf] is very clearly marked as *private* and you have no business using it unless you're creating a qt module.