### PR TITLE
Fix an unexpected behavior of a candidate window after my patch.

### DIFF
--- a/qt5/immodule/quimplatforminputcontext.cpp
+++ b/qt5/immodule/quimplatforminputcontext.cpp
@@ -182,7 +182,7 @@ void QUimPlatformInputContext::setFocus()
     focusedInputContext = this;
     disableFocusedContext = false;
 
-    if (proxy != NULL && candwinIsActive)
+    if (proxy != NULL && candwinIsActive && m_candwin_assert)
         proxy->popup();
 
     m_helperManager->checkHelperConnection(m_uc);
@@ -460,6 +460,7 @@ void QUimPlatformInputContext::reset()
     qDebug("reset()");
 #endif
     candwinIsActive = false;
+    m_candwin_assert = false;
 
     if (proxy != NULL)
 	    proxy->hide();
@@ -559,8 +560,10 @@ void QUimPlatformInputContext::cand_activate_cb(void *ptr, int nr, int displayLi
 
     if (ic->proxy == NULL)
 	ic->proxy = __createCandidateWindow(ic);
-    if (ic->proxy != NULL)
+    if (ic->proxy != NULL) {
+        ic->m_candwin_assert = true;
 	ic->proxy->candidateActivate(nr, displayLimit);
+    }
 }
 
 void QUimPlatformInputContext::cand_select_cb(void *ptr, int index)
@@ -592,6 +595,7 @@ void QUimPlatformInputContext::cand_deactivate_cb(void *ptr)
 #endif
 
     QUimPlatformInputContext *ic = static_cast<QUimPlatformInputContext*>(ptr);
+    ic->m_candwin_assert = false;
     if (ic->proxy != NULL)
     {
 	    ic->proxy->deactivateCandwin();

--- a/qt5/immodule/quimplatforminputcontext.h
+++ b/qt5/immodule/quimplatforminputcontext.h
@@ -134,6 +134,7 @@ private:
 
     QUimTextUtil *m_textUtil;
     bool candwinIsActive;
+    bool m_candwin_assert;
     bool m_isAnimating;
 
     uim_context m_uc;


### PR DESCRIPTION
After applying the patch which fixes the issue 112, we sometimes observe the following strange behavior of a candidate window in qt5.

1) First invoke some qt5 program like kwrite, 
2) Then input some (preeidt) string and type the conversion key several times very quickly, and as soon as possible,  cancel them by hitting ESC. 
As a result, the candidate window is cancelled before its pop-up (so you never see the candidate window). 
3) Now, once focus out to other window and then focus in to the original window, 
4) Then the candidate window appears unexpectedly.

This is due to a timing issue between "pop-up" vs "hide" operations of a candidate window,
and this request resolves the issue. 

