### PR TITLE
quimplatforminputcontext.cpp: Remove #define ENABLE_DEBUG

### DIFF
--- a/qt5/immodule/quimplatforminputcontext.cpp
+++ b/qt5/immodule/quimplatforminputcontext.cpp
@@ -61,8 +61,6 @@ QUimHelperManager *QUimPlatformInputContext::m_helperManager = 0;
 
 static int unicodeToUKey(ushort c);
 
-#define ENABLE_DEBUG
-
 QUimPlatformInputContext::QUimPlatformInputContext(const char *imname)
 : candwinIsActive(false), m_isAnimating(false), m_uc(0)
 {


### PR DESCRIPTION
Fix debug messages printed to stderr in non-debug builds.

Guessing it was added in during a debugging session and then was never removed.