### PR TITLE
Fix unportable test(1) == operator usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -864,7 +864,7 @@ AM_CONDITIONAL(GNOME3_APPLET, test "x$enable_gnome3_applet" = xyes)
 
 if test "x$enable_gnome3_applet" = xyes; then
   AC_ARG_WITH([libpanel-applet-dir], [], [LIBPANEL_APPLET_DIR=$withval], [LIBPANEL_APPLET_DIR=""])
-  if test "$LIBPANEL_APPLET_DIR" == ""; then
+  if test "$LIBPANEL_APPLET_DIR" = ""; then
     LIBPANEL_APPLET_DIR=`$PKG_CONFIG --variable=libpanel_applet_dir libpanel-applet`
   fi
   AC_SUBST(LIBPANEL_APPLET_DIR)


### PR DESCRIPTION
"==" operator for test(1) is not in POSIX Standards, just a "=" should be used.