### PR TITLE
Fix to set libedit path from configure option properly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1311,8 +1311,8 @@ if test "x$with_libedit" != xno; then
   if test "x$with_libedit" = xyes; then
     libedit_path=/usr
   else
-    with_libedit=yes
     libedit_path="$with_libedit"
+    with_libedit=yes
   fi
 
   saved_CPPFLAGS=$CPPFLAGS


### PR DESCRIPTION
It is unexpected behaviour that --with-libedit=/usr result in libedit_path=yes then -Iyes/include and -Lyes/lib.