### PR TITLE
xim/main.cpp: Fix building against clang

### DIFF
--- a/xim/main.cpp
+++ b/xim/main.cpp
@@ -65,7 +65,7 @@ int g_option_mask;
 int scr_width, scr_height;
 int host_byte_order;
 
-#define VERSION_NAME "uim-xim under the way! Version "PACKAGE_VERSION"\n"
+#define VERSION_NAME "uim-xim under the way! Version " PACKAGE_VERSION "\n"
 const char *version_name=VERSION_NAME;
 const char *usage=
 "--help , --version :Show usage or version\n"


### PR DESCRIPTION
This fixes the following error:
``main.cpp:68:55: error: invalid suffix on literal; C++11 requires a space between literal and identifier``

It have been tested with clang 6.0.1 under gentoo.