### PR TITLE
Take care strtonum(3) on NetBSD-8

### DIFF
--- a/replace/os_dep.h
+++ b/replace/os_dep.h
@@ -135,6 +135,9 @@ long long strtoll(const char *, char **, int);
 #ifndef HAVE_STRTONUM
 #define strtonum	uim_internal_strtonum
 long long strtonum(const char *numstr, long long minval, long long maxval, const char **errstrp);
+#elif defined(__NetBSD__)
+#define _OPENBSD_SOURCE
+#include <stdlib.h>
 #endif
 
 #ifdef HAVE_POLL_H


### PR DESCRIPTION
strtonum(3) is an OpenBSD extension on NetBSD-8,
so _OPENBSD_SOURCE must be defined before stdlib.h