### PR TITLE
fixes a bug that causes the wsl command to hang on uim-fep

### DIFF
--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -874,6 +874,8 @@ static void main_loop(void)
       } else {
 
         int i;
+        char master_buf[10];
+        int master_buf_len = 0;
         for (i = 0; i < len; i++) {
           int key_len;
           int *key_and_key_len = escape_sequence2key(buf + i, len - i);
@@ -935,9 +937,11 @@ static void main_loop(void)
             }
             if (raw && !g_start_preedit) {
               if (key_state & UMod_Alt) {
-                write(s_master, buf + i - 1, key_len + 1);
+                memcpy(&master_buf[master_buf_len], buf + i - 1, key_len + 1);
+                master_buf_len += key_len + 1;
               } else {
-                write(s_master, buf + i, key_len);
+                memcpy(&master_buf[master_buf_len], buf + i, key_len);
+                master_buf_len += key_len;
               }
             }
           }
@@ -945,6 +949,7 @@ static void main_loop(void)
           key_state = 0;
           i += (key_len - 1);
         }
+        write(s_master, master_buf, master_buf_len);
       }
     }
 

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -938,10 +938,10 @@ static void main_loop(void)
             }
             if (raw && !g_start_preedit) {
               if (key_state & UMod_Alt) {
-                memcpy(&master_buf[master_buf_len], buf + i - 1, key_len + 1);
+                memcpy(master_buf + master_buf_len, buf + i - 1, key_len + 1);
                 master_buf_len += key_len + 1;
               } else {
-                memcpy(&master_buf[master_buf_len], buf + i, key_len);
+                memcpy(master_buf + master_buf_len, buf + i, key_len);
                 master_buf_len += key_len;
               }
             }

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -866,7 +866,8 @@ static void main_loop(void)
       buf[len] = '\0';
       debug(("read \"%s\"\n", buf));
 
-      if (len >= 10 && !g_opt.print_key) {
+#define LARGE_INPUT_THRESHOLD 10
+      if (len >= LARGE_INPUT_THRESHOLD && !g_opt.print_key) {
         /* ペーストなどで大量に入力されたときは変換しない */
         if (!g_start_preedit) {
           write(s_master, buf, len);
@@ -874,7 +875,7 @@ static void main_loop(void)
       } else {
 
         int i;
-        char master_buf[10];
+        char master_buf[LARGE_INPUT_THRESHOLD];
         int master_buf_len = 0;
         for (i = 0; i < len; i++) {
           int key_len;
@@ -952,6 +953,7 @@ static void main_loop(void)
         write(s_master, master_buf, master_buf_len);
       }
     }
+#undef LARGE_INPUT_THRESHOLD
 
 
     /* input from pty (child process) */


### PR DESCRIPTION
The wsl command hangs on uim-fep.

$ uim-fep -e /mnt/c/windows/system32/cmd.exe /c dir

The cause of the hang is unknown, but could be fixed by writing the input data to the pty at once.
