### PR TITLE
Fix uim-im-switcher-gtk3 crash when input method list is empty

### DIFF
--- a/gtk2/switcher/gtk.c
+++ b/gtk2/switcher/gtk.c
@@ -242,6 +242,7 @@ save_default_im()
 {
   if (custom_enabled) {
     gchar *im_name = get_selected_im_name();
+    if(!im_name) return;
 
     uim_scm_callf("custom-set-value!",
 		  "yy",

--- a/gtk2/switcher/gtk.c
+++ b/gtk2/switcher/gtk.c
@@ -242,7 +242,9 @@ save_default_im()
 {
   if (custom_enabled) {
     gchar *im_name = get_selected_im_name();
-    if(!im_name) return;
+    if (!im_name) {
+      return;
+    }
 
     uim_scm_callf("custom-set-value!",
 		  "yy",


### PR DESCRIPTION
I found that the immediate cause of the bug #161 is `save_default_im()` in `gtk2/switcher/gtk.c` does not check if the return value of `get_selected_im_name()` is NULL, and the value is dereferenced by `symbol_name_hash()` in `sigscheme/src/symbol.c`.
I could solve this problem by adding early return from `save_default_im()` when `im_name` is NULL.