### PR TITLE
Fix uim-toolbar-gtk3 not to be grabbed by right click

### DIFF
--- a/gtk2/toolbar/standalone-gtk.c
+++ b/gtk2/toolbar/standalone-gtk.c
@@ -76,6 +76,10 @@ button_press_event_cb(GtkWidget *widget, GdkEventButton *event, gpointer data)
   GdkDevice *device = gtk_get_current_event_device();
 #endif
 
+  // do nothing unless left mouse button is pressed
+  if (event->button != 1)
+    return FALSE;
+
   switch (event->type) {
   case GDK_BUTTON_PRESS:
     cursor = gdk_cursor_new(GDK_FLEUR);

--- a/gtk2/toolbar/standalone-gtk.c
+++ b/gtk2/toolbar/standalone-gtk.c
@@ -76,7 +76,7 @@ button_press_event_cb(GtkWidget *widget, GdkEventButton *event, gpointer data)
   GdkDevice *device = gtk_get_current_event_device();
 #endif
 
-  // do nothing unless left mouse button is pressed
+  /* do nothing unless left mouse button is pressed */
   if (event->button != 1)
     return FALSE;
 
@@ -383,4 +383,3 @@ main(int argc, char *argv[])
 
   return 0;
 }
-


### PR DESCRIPTION
`uim-toolbar-gtk3` (and probably `uim-toolbar-gtk` also does) accepts any mouse button to grab window.
But right click is also used to open context menu.
When we do right click on toolbar, context menu is opened, and toolbar is grabbed.

I fixed this bug by ignoring mouse button events unless the event is invoked by left click.

NOTE: With this fix, `button_press_event_cb()` will ignore any clicks other than left click. (so, middle click is also ignored)
This is because I thought middle click (and undo/redo button in many mice) is usually not used to grab window.