### PR TITLE
Fix select-url-from-im to return appropriate URL

### DIFF
--- a/scm/uim-help.scm
+++ b/scm/uim-help.scm
@@ -59,7 +59,7 @@
 (define (select-url-from-im im)
   (or (and-let* ((i (retrieve-im im))
                  (ret (assoc (im-lang i) toolbar-help-url-locale-alist)))
-         (format "~aUim~a" (cdr ret) (make-wikiname im)))
+         (format "~a/Uim~a" (cdr ret) (make-wikiname im)))
       toolbar-help-url))
 
 (define (uim-help args)


### PR DESCRIPTION
URLs returned by select-url-from-im was like `https://github.com/uim/uim/wikiUimNameOfIM`,
but appropriate URL is `https://github.com/uim/uim/wiki/UimNameOfIM`. (added a slash between `wiki` and `UimNameOfIM`.)