### PR TITLE
Add support for building with --disable-nls without intltool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,10 @@ ACLOCAL_AMFLAGS = -I m4.generated -I m4
 
 SUBDIRS = m4 doc replace sigscheme uim scm test test2 \
           gtk2 gtk3 qt3 qt4 qt5 notify
-SUBDIRS += xim fep emacs po pixmaps examples tables byeoru-data
+SUBDIRS += xim fep emacs pixmaps examples tables byeoru-data
+if USE_NLS
+  SUBDIRS += po
+endif
 
 EXTRA_DIST = RELNOTE autogen.sh make-dist.sh \
 	uim.pc.in uim.desktop \
@@ -14,7 +17,11 @@ pkgconfig_DATA = uim.pc
 desktopdir = $(datadir)/applications
 desktop_in_files = uim.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
-@INTLTOOL_DESKTOP_RULE@
+if USE_NLS
+  @INTLTOOL_DESKTOP_RULE@
+else
+  %.desktop: %.desktop.in ; cp $< $@
+endif
 
 DIST_NAME = $(PACKAGE)-$(VERSION)
 #RELEASE_TAG     = master

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
-${AUTORECONF:-autoreconf} --force --install "$@" \
-  && intltoolize --copy --force --automake
+set -e
+
+${AUTORECONF:-autoreconf} --force --install "$@"
+if command -v intltoolize >/dev/null; then
+    intltoolize --copy --force --automake
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -761,6 +761,7 @@ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE",[gettext package name])
 
 AM_GNU_GETTEXT([external], [need-ngettext])
 AM_GNU_GETTEXT_VERSION([0.17])
+AM_CONDITIONAL([USE_NLS], [test "x$USE_NLS" = xyes])
 
 # FIXME: Probably voilent way  -- YamaKen 2005-01-07
 if test "x$prefix" = xNONE; then
@@ -1362,7 +1363,11 @@ AM_CONDITIONAL(NEED_STRSEP_C, test $ac_cv_func_strsep = no)
 AM_CONDITIONAL(GCC, test "x$ac_cv_c_compiler_gnu" = xyes)
 AM_CONDITIONAL(GXX, test "x$ac_cv_cxx_compiler_gnu" = xyes)
 
-IT_PROG_INTLTOOL([0.36.3], [no-xml])
+if test "x$USE_NLS" = xyes; then
+  m4_ifdef([IT_PROG_INTLTOOL],
+           [IT_PROG_INTLTOOL([0.36.3],[no-xml])],
+           [AC_MSG_ERROR([nls support requires intltool to be installed.])])
+fi
 
 dnl **********************************
 dnl *** test for KDE3 applet.. XXX ***

--- a/gtk2/toolbar/Makefile.am
+++ b/gtk2/toolbar/Makefile.am
@@ -26,7 +26,11 @@ server_DATA = GNOME_UimApplet.server
 server_in_files = $(server_DATA:=.in)
 server_in_in_files = $(server_in_files:=.in)
 
-@INTLTOOL_SERVER_RULE@
+if USE_NLS
+  @INTLTOOL_SERVER_RULE@
+else
+  %.server: %.server.in ; cp $< $@
+endif
 
 $(server_in_files): $(server_in_in_files) Makefile
 	$(SED) s,@LIBEXECDIR@,$(libexecdir),g <$< >$@.tmp

--- a/gtk3/toolbar/Makefile.am
+++ b/gtk3/toolbar/Makefile.am
@@ -36,9 +36,13 @@ $(applet_in_files): $(applet_in_in_files) Makefile
 	$(SED) s,@APPLET_LOCATION@,$(APPLET_LOCATION),g <$< >$@.tmp
 	$(SED) s,@UIM_PIXMAPSDIR@,$(uim_pixmapsdir),g <$@.tmp >$@
 
-po_files = $(wildcard $(top_srcdir)/po/*.po)
-$(applet_DATA): $(applet_in_files) $(INTLTOOL_MERGE) $(po_files)
-	LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< $@ 
+if USE_NLS
+  po_files = $(wildcard $(top_srcdir)/po/*.po)
+  $(applet_DATA): $(applet_in_files) $(INTLTOOL_MERGE) $(po_files) ;\
+    LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< $@
+else
+  $(applet_DATA): $(applet_in_files) ; cp $< $@
+endif
 
 DISTCLEANFILES = UimApplet.panel-applet.in UimApplet.panel-applet \
 		 UimApplet.panel-applet.in.tmp


### PR DESCRIPTION
This changes the build system such that passing --disable-nls disables
the requirement for intltool.