### PR TITLE
uim-fep 24bit color support

### DIFF
--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -970,15 +970,10 @@ static void set_attr(const char *str, int len)
                   nr_ext_params = 3;
                 }
 
-                for (j = 0; j < nr_ext_params; j++) {
+                for (j = 0; j < nr_ext_params && i < nr_params; j++) {
                   i++;
-                  if (i < nr_params) {
-                    if (0 <= params[i] && params[i] <= 255) {
-                      *ext_color_dst |= params[i] << (j * 8);
-                    }
-                  }
-                  else {
-                    break;
+                  if (0 <= params[i] && params[i] <= 255) {
+                    *ext_color_dst |= params[i] << (j * 8);
                   }
                 }
               }

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -964,13 +964,13 @@ static void set_attr(const char *str, int len)
                 int nr_ext_params;
                 if (params[i] == 5) {
                   *ext_color_dst = EXT_COLOR_256;
-                  ext_param_num = 1;
+                  nr_ext_params = 1;
                 } else {
                   *ext_color_dst = EXT_COLOR_24BIT;
-                  ext_param_num = 3;
+                  nr_ext_params = 3;
                 }
 
-                for (j = 0; j < ext_param_num; j++) {
+                for (j = 0; j < nr_ext_params; j++) {
                   i++;
                   if (i < nr_params) {
                     if (0 <= params[i] && params[i] <= 255) {

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -965,9 +965,7 @@ static void set_attr(const char *str, int len)
                 if (params[i] == 5) {
                   *ext_color_dst = EXT_COLOR_256;
                   ext_param_num = 1;
-                }
-                else
-                {
+                } else {
                   *ext_color_dst = EXT_COLOR_24BIT;
                   ext_param_num = 3;
                 }

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -73,9 +73,6 @@
 
 #define my_putp(str) tputs(str, 1, my_putchar);
 
-#define EXT_COLOR_256   (1 << 24)
-#define EXT_COLOR_24BIT (1 << 25)
-
 /* 初期化したらTRUE */
 static int s_init = FALSE;
 /* 現在のカーソル位置 */
@@ -848,9 +845,9 @@ static const char *attr2escseq(const struct attribute_tag *attr)
     strlcat(escseq, numstr, sizeof(escseq));
   }
   strlcat(escseq, "m", sizeof(escseq));
-  debug2(("attr2escseq underline = %d standout = %d bold = %d blink = %d fore = %d back = %d\n",
+  debug2(("attr2escseq underline = %d standout = %d bold = %d blink = %d fore = %d(0x%x) back = %d(0x%x)\n",
       attr->underline, attr->standout, attr->bold, attr->blink,
-      attr->foreground, attr->background));
+      attr->foreground, attr->foreground, attr->background, attr->background));
   debug2(("attr2escseq = %s\n", escseq));
   return escseq;
 }

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -961,7 +961,7 @@ static void set_attr(const char *str, int len)
             i++;
             if (i < nr_params) {
               if (params[i] == 2 || params[i] == 5) {
-                int ext_param_num;
+                int nr_ext_params;
                 if (params[i] == 5) {
                   *ext_color_dst = EXT_COLOR_256;
                   ext_param_num = 1;

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -970,7 +970,7 @@ static void set_attr(const char *str, int len)
                   ext_param_num = 3;
                 }
 
-                for(j = 0; j < ext_param_num; j++) {
+                for (j = 0; j < ext_param_num; j++) {
                   i++;
                   if (i < nr_params) {
                     if (0 <= params[i] && params[i] <= 255) {

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -783,7 +783,7 @@ static void change_background_attr(struct attribute_tag *from, struct attribute_
  */
 static const char *attr2escseq(const struct attribute_tag *attr)
 {
-  static char escseq[20];
+  static char escseq[40];
   char numstr[20];
   int add_semicolon = FALSE;
   if (!attr->underline && !attr->standout && !attr->bold && !attr->blink

--- a/fep/escseq.h
+++ b/fep/escseq.h
@@ -34,6 +34,9 @@
 #ifndef UIM_FEP_ESCSEQ_H
 #define UIM_FEP_ESCSEQ_H
 
+#define EXT_COLOR_256   (1 << 24)
+#define EXT_COLOR_24BIT (1 << 25)
+
 struct point_tag {
   int row;
   int col;

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -403,10 +403,10 @@ opt_end:
   }
 
   if (attr_uim.foreground == UNDEFINED) {
-    attr_uim.foreground = FALSE;
+    attr_uim.foreground = 39;
   }
   if (attr_uim.background == UNDEFINED) {
-    attr_uim.background = FALSE;
+    attr_uim.background = 49;
   }
 
   if (!isatty(g_win_in)) {
@@ -577,13 +577,13 @@ static int make_color_escseq(const char *instr, struct attribute_tag *attr)
     attr->bold = (attr->foreground & 8) == 8;
     attr->foreground = (attr->foreground & 7) + 30;
   } else {
-    attr->foreground = FALSE;
+    attr->foreground = 39;
   }
   if (attr->background != UNDEFINED) {
     attr->blink = (attr->background & 8) == 8;
     attr->background = (attr->background & 7) + 40;
   } else {
-    attr->background = FALSE;
+    attr->background = 49;
   }
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Two bugs have been fixed.

1 The color of preedit of uim-fep is not correct on 24bit color-capable vim.

When the -c option of uimfep is not specified, uim-fep does not set the foreground color and background color when drawing the preedit.  If you use a vim that supports 24-bit color as shown in the figure below, the background color of uim-fep's preedit and status line will be the color of the vim's status line.
![uim-fep1](https://user-images.githubusercontent.com/12369962/170795042-6258056e-d840-4ee1-9f9b-2cd828db913a.png)

Therefore, even if foreground color and background color are not specified, the default color is set when drawing uim-fep's preedit. After the fix, the color of the preedit and status line will not be the color of the vim status line as shown below.
![uim-fep3](https://user-images.githubusercontent.com/12369962/170795054-c260f026-6d9d-4e58-87bb-2d4210162091.png)

2 If the app uses 24bit color, the color will change after uim-fep's preedit drawing.

The following figure shows the situation where 'aa' is output with red (255/0/0) set in 24bit color, and then a preedit is drawn in uim-fep, and then 'aa' is output again. The first 'aa' is red, but the second 'aa' is the default black.
![uim-fep2](https://user-images.githubusercontent.com/12369962/170795101-9f24383a-7818-450a-b069-7ce3a0f4b44a.png)

If I fix uim-fep to restore the app's 24bit color setting after the preedit drawing, everything is red as shown below.
![uim-fep4](https://user-images.githubusercontent.com/12369962/170795210-9ee0f4fc-6dd6-4bf4-9a1c-86a9ebd6e820.png)
