### PR TITLE
configure: Fix snprintf check for strict(er) C99 compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -595,7 +595,7 @@ if test "x$ac_cv_func_snprintf" = xyes; then
 	AC_RUN_IFELSE(
 		[AC_LANG_SOURCE([[
 #include <stdio.h>
-int main(void){char b[5];snprintf(b,5,"123456789");exit(b[4]!='\0');}
+int main(void){char b[5];snprintf(b,5,"123456789");return b[4]!='\0';}
 		]])],
 		[AC_MSG_RESULT(yes)],
 		[


### PR DESCRIPTION
C99 removed support for implicit function declarations.  The test calls the undeclared exit function, so it may fail incorrectly with C99 compilers.  Return from main instead to report the test result.