### PR TITLE
sizeof('c')=4, not 1: fix overallocation

### DIFF
--- a/examples/uim-custom/uim-custom-variable.c
+++ b/examples/uim-custom/uim-custom-variable.c
@@ -43,7 +43,7 @@ choice_items_to_str(const struct uim_custom_choice **items, const char *sep)
   char *buf, *bufp;
   const struct uim_custom_choice **item;
 
-  buf_size = sizeof('\0');
+  buf_size = 1 /* NUL */;
   for (item = items; *item; item++) {
     if (item != items)
       buf_size += strlen(sep);


### PR DESCRIPTION
As found by DCS `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793