### PR TITLE
Fix cast usage for `isspace`

### DIFF
--- a/qt3/immodule/quiminputcontext_compose.cpp
+++ b/qt3/immodule/quiminputcontext_compose.cpp
@@ -933,7 +933,7 @@ int QUimInputContext::get_compose_filename(char *filename, size_t len)
 	char *p = buf;
 	int n;
 	char *args[2], *from, *to;
-	while ((unsigned char)isspace(*p)) {
+	while (isspace((unsigned char)*p)) {
 	    ++p;
 	}
 	if (iscomment(*p)) {
@@ -966,7 +966,7 @@ parse_line(char *line, char **argv, int argsize)
     char *p = line;
 
     while (argc < argsize) {
-	while ((unsigned char)isspace(*p)) {
+	while (isspace((unsigned char)*p)) {
 	    ++p;
 	}
 	if (*p == '\0') {

--- a/qt4/immodule/quiminputcontext_compose.cpp
+++ b/qt4/immodule/quiminputcontext_compose.cpp
@@ -945,7 +945,7 @@ int QUimInputContext::get_compose_filename(char *filename, size_t len)
         int n;
         char *args[2], *from, *to;
         // isspace for tab doesn't seem to work with Qt4...
-        while (static_cast<unsigned char>(isspace(*p)) || *p == '\t') {
+        while (isspace(static_cast<unsigned char>(*p)) || *p == '\t') {
             ++p;
         }
         if (iscomment(*p)) {
@@ -980,7 +980,7 @@ parse_line(char *line, char **argv, int argsize)
 
     while (argc < argsize) {
         // isspace for tab doesn't seem to work with Qt4...
-        while (static_cast<unsigned char>(isspace(*p)) || *p == '\t') {
+        while (isspace(static_cast<unsigned char>(*p)) || *p == '\t') {
             ++p;
         }
         if (*p == '\0') {


### PR DESCRIPTION
It is required to cast for the argment, not return value.