### PR TITLE
gtk-immodule: Don't draw an indicator yourself

### DIFF
--- a/gtk2/immodule/caret-state-indicator.c
+++ b/gtk2/immodule/caret-state-indicator.c
@@ -80,28 +80,6 @@ caret_state_indicator_timeout(gpointer data)
 }
 
 static gint
-#if GTK_CHECK_VERSION(2, 90, 0)
-caret_state_indicator_paint_window(GtkWidget *window, cairo_t *cr)
-#else
-caret_state_indicator_paint_window(GtkWidget *window)
-#endif
-{
-#if GTK_CHECK_VERSION(2, 90, 0)
-  gtk_render_frame(gtk_widget_get_style_context(window), cr,
-             0, 0,
-             gtk_widget_get_allocated_width(window),
-             gtk_widget_get_allocated_height(window));
-#else
-  gtk_paint_flat_box(gtk_widget_get_style(window),
-             gtk_widget_get_window(window),
-             GTK_STATE_NORMAL, GTK_SHADOW_OUT, NULL, GTK_WIDGET(window),
-             "tooltip", 0, 0, -1, -1);
-#endif
-
-  return FALSE;
-}
-
-static gint
 caret_state_indicator_destroy_cb(GtkWidget *window)
 {
   GList *label_list, *frame_list;
@@ -136,17 +114,7 @@ caret_state_indicator_new(void)
   gtk_window_set_default_size(GTK_WINDOW(window),
 			      DEFAULT_WINDOW_WIDTH,
 			      DEFAULT_WINDOW_HEIGHT);
-  gtk_widget_set_app_paintable(window, TRUE);
 
-#if GTK_CHECK_VERSION(2, 90, 0)
-  g_signal_connect(window, "draw",
-		   G_CALLBACK(caret_state_indicator_paint_window), 
-		   NULL);
-#else
-  g_signal_connect(window, "expose_event",
-		   G_CALLBACK(caret_state_indicator_paint_window), 
-		   NULL);
-#endif
   g_signal_connect(window, "destroy",
 		   G_CALLBACK(caret_state_indicator_destroy_cb), 
 		   NULL);


### PR DESCRIPTION
Commit 334238f595e223e37da32959f58d6e6dbce53de1 added code to draw a frame. I think commit 59dab654dc4a948efb6e786808dcce7a5d019c07 made it unnecessary by adding a frame widget.
Fix #203.