### PR TITLE
configure: fix typo in command name that prevented effectively running

### DIFF
--- a/m4/ax_path_qmake4.m4
+++ b/m4/ax_path_qmake4.m4
@@ -30,7 +30,7 @@ AC_DEFUN([AX_PATH_QMAKE4], [
   ax_guessed_qt4_dirs="/usr/local/lib/qt4/bin:${ax_guessed_qt4_dirs}"
   ax_guessed_qt4_dirs="/usr/lib/qt4/bin:${ax_guessed_qt4_dirs}"
   if type dpkg-architecture > /dev/null 2>&1; then
-    multiarch=$(dpkg-archtecture --query DEB_BUILD_MULTIARCH)
+    multiarch=$(dpkg-architecture --query DEB_BUILD_MULTIARCH)
     ax_guessed_qt4_dirs="/usr/lib/${multiarch}/qt4/bin:${ax_guessed_qt4_dirs}"
   fi
   AC_PROG_EGREP


### PR DESCRIPTION
The check was for dpkg-architecture, but actually running it would elide the "i".

Detected on Gentoo (!!!) with dpkg coincidentally installed, because it is logged as a QA warning:

```
 * QA Notice: command not found:
 *
 *      ./configure: 19734: dpkg-archtecture: not found
 *      ./configure: 19942: dpkg-archtecture: not found
 ```