### PR TITLE
configure: detect struct sockcred

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -694,6 +694,7 @@ if test "x$ac_cv_have_struct_sockaddr_storage" = xyes; then
 fi
 
 dnl cred related
+AC_CHECK_TYPES([struct sockcred], [], [],[[#include <sys/socket.h>]])
 AC_CACHE_CHECK([for struct cmsgcred], ac_cv_have_struct_cmsgcred, [
 	AC_TRY_COMPILE(
 		[

--- a/replace/getpeereid.c
+++ b/replace/getpeereid.c
@@ -43,9 +43,6 @@ int
 getpeereid(int s, uid_t *euid, gid_t *gid)
 {
 /* Credentials structure */
-#ifdef __NetBSD__	/* XXX: should use autoconf */
-#define HAVE_STRUCT_SOCKCRED
-#endif
 #if defined(HAVE_STRUCT_CMSGCRED)
         typedef struct cmsgcred Cred;
 


### PR DESCRIPTION
I don't know why not using `AC_CHECK_TYPES` for other struct type detection, but it is sufficient for `struct sockcred`. 