### PR TITLE
Avoid to redefine _OPENBSD_SOURCE on NetBSD

### DIFF
--- a/replace/os_dep.h
+++ b/replace/os_dep.h
@@ -135,7 +135,7 @@ long long strtoll(const char *, char **, int);
 #ifndef HAVE_STRTONUM
 #define strtonum	uim_internal_strtonum
 long long strtonum(const char *numstr, long long minval, long long maxval, const char **errstrp);
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) && !defined(_OPENBSD_SOURCE)
 #define _OPENBSD_SOURCE
 #include <stdlib.h>
 #endif


### PR DESCRIPTION
It may be already defined with autoconf or users.