### PR TITLE
uim-helper: fix `LOCAL_CRED` usage condition

### DIFF
--- a/uim/uim-helper-client.c
+++ b/uim/uim-helper-client.c
@@ -102,7 +102,7 @@ int uim_helper_init_client_fd(void (*disconnect_cb)(void))
   }
   fcntl(fd, F_SETFD, fcntl(fd, F_GETFD, 0) | FD_CLOEXEC);
   
-#ifdef LOCAL_CREDS /* for NetBSD */
+#if !defined(HAVE_GETPEEREID) && defined(LOCAL_CREDS)
   /* Set the socket to receive credentials on the next message */
   {
     int on = 1;

--- a/uim/uim-helper-server.c
+++ b/uim/uim-helper-server.c
@@ -254,7 +254,7 @@ accept_new_connection(int server_fd)
     return UIM_FALSE;
   }
   cl->fd = new_fd;
-#ifdef LOCAL_CREDS	/* for NetBSD */
+#if !defined(HAVE_GETPEEREID) && defined(LOCAL_CREDS)
   {
     char buf[1] = { '\0' };
     write(cl->fd, buf, 1);


### PR DESCRIPTION
It is required for platforms missing `getpeereid()` and suppliment function is implemented with `LOCAL_CREDS`.
(NetBSD-5.0 and later have the function, so not "for NetBSD")

Fixed random unwanted behaviour on recent NetBSD.