### PR TITLE
uim-chardict-qt: fix to work as input pad

### DIFF
--- a/qt3/chardict/Makefile.am
+++ b/qt3/chardict/Makefile.am
@@ -29,7 +29,7 @@ uim_chardict_qt_SOURCES = \
 uim_chardict_qt_CXXFLAGS = @UIM_QT_CXXFLAGS@ -DBUSHUDICT=\"$(datadir)/uim/helperdata/bushu.t\"
 
 uim_chardict_qt_LDFLAGS  = @UIM_QT_LDFLAGS@
-uim_chardict_qt_LDADD    = @LTLIBINTL@
+uim_chardict_qt_LDADD    = $(top_builddir)/uim/libuim.la @LTLIBINTL@ 
 qt.cpp: qt.moc
 
 bushuviewwidget.cpp: bushuviewwidget.moc

--- a/qt3/chardict/unicodeviewwidget.cpp
+++ b/qt3/chardict/unicodeviewwidget.cpp
@@ -348,7 +348,15 @@ void UnicodeViewWidget::slotUnicodeBlockSelected( QListViewItem *item )
     QStringList charList;
     for ( uint d = block->getStartHex(); d < block->getEndHex(); d++ )
     {
-        charList.append( QString( QChar( d ) ) );
+        QString charStr;
+        if ( d >= 0x10000 ) {
+            // surrogate pair
+            charStr += QChar( ushort( ( d >> 10 ) + 0xd7c0 ) );
+            charStr += QChar( ushort( ( d % 0x400 ) + 0xdc00 ) );
+        } else {
+            charStr = QChar( d );
+        }
+        charList.append( charStr );
     }
 
     m_charGridView->setCharacters( charList );


### PR DESCRIPTION
* set UIM icon
* fix to send selected charactor
* fix to handle surrogate pairs

  Qt3 dose not support surrogate pair, so such chars will be displayed as two To-Fu.  But it is better than display and select wrong chars.