### PR TITLE
gtk3: remove leftover #endif

### DIFF
--- a/gtk3/pref/gtk.c
+++ b/gtk3/pref/gtk.c
@@ -36,7 +36,6 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms-compat.h>
-#endif
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
This fixes gtk3 module not building