### PR TITLE
qt3: fix missing include path

### DIFF
--- a/qt3/candwin/Makefile.am
+++ b/qt3/candwin/Makefile.am
@@ -3,6 +3,7 @@ if QT
 AM_CPPFLAGS =					\
 	-I$(top_builddir)/uim			\
 	-I$(top_srcdir)/replace			\
+	-I$(top_srcdir)/qt3			\
 	-I$(top_srcdir)
 
 HEADER_FILES = qt.h

--- a/qt3/chardict/Makefile.am
+++ b/qt3/chardict/Makefile.am
@@ -4,6 +4,7 @@ if QT
 AM_CPPFLAGS =					\
 	-I$(top_builddir)/uim			\
 	-I$(top_srcdir)/replace			\
+	-I$(top_srcdir)/qt3			\
 	-I$(top_srcdir)
 
 HEADER_FILES = \

--- a/qt3/pref/Makefile.am
+++ b/qt3/pref/Makefile.am
@@ -4,6 +4,7 @@ if QT
 AM_CPPFLAGS =					\
 	-I$(top_builddir)/uim			\
 	-I$(top_srcdir)/replace			\
+	-I$(top_srcdir)/qt3			\
 	-I$(top_srcdir)
 
 if PREF

--- a/qt3/switcher/Makefile.am
+++ b/qt3/switcher/Makefile.am
@@ -2,6 +2,7 @@ if QT
 AM_CPPFLAGS =					\
 	-I$(top_builddir)/uim			\
 	-I$(top_srcdir)/replace			\
+	-I$(top_srcdir)/qt3			\
 	-I$(top_srcdir)
 
 HEADER_FILES = qt.h

--- a/qt3/toolbar/Makefile.am
+++ b/qt3/toolbar/Makefile.am
@@ -4,6 +4,7 @@ if QT
 AM_CPPFLAGS =					\
 	-I$(top_builddir)/uim			\
 	-I$(top_srcdir)/replace			\
+	-I$(top_srcdir)/qt3			\
 	-I$(top_srcdir)
 QT_CXXFLAGS = $(UIM_QT_CXXFLAGS)
 QT_LDFLAGS  = $(UIM_QT_LDFLAGS)


### PR DESCRIPTION
It wad dropped in coverting to use AM_CPPFLAGS and required for "qtgettext.h".