### PR TITLE
uim_get_uim_fd: add

### DIFF
--- a/uim/uim-helper.c
+++ b/uim/uim-helper.c
@@ -343,6 +343,12 @@ uim_unset_uim_fd(uim_context uc)
   uc->uim_fd = -1;
 }
 
+int
+uim_get_uim_fd(uim_context uc)
+{
+  return uc->uim_fd;
+}
+
 /* Public API for uim_issetugid(). */
 /* TODO: should be renamed to uim_helper_issetugid() */
 uim_bool

--- a/uim/uim-helper.h
+++ b/uim/uim-helper.h
@@ -59,8 +59,9 @@ char *uim_helper_buffer_append(char *buf,
 void uim_helper_buffer_shift(char *buf, int count);
 char *uim_helper_buffer_get_message(char *buf);
 
-void uim_set_uim_fd(uim_context, int);
-void uim_unset_uim_fd(uim_context);
+void uim_set_uim_fd(uim_context uc, int fd);
+void uim_unset_uim_fd(uim_context uc);
+int uim_get_uim_fd(uim_context uc);
 
 uim_bool
 uim_helper_is_setugid(void);


### PR DESCRIPTION
It's useful to maintain helper file descriptor by
`uim_{set,unset}_uim_fd()`. If we also have getter, we can use `uim_helper_send_message()` with file descriptor maintained by `uim_{set,unset,get}_uim_fd()`.