### PR TITLE
ci: Use Debian 13 except release image

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,12 +21,12 @@ jobs:
           - arch-linux-gtk3
           - arch-linux-qt6
           - arch-linux-tqt
-          - debian-12-core
-          - debian-12-gtk2
-          - debian-12-gtk3
-          - debian-12-qt5
-          - debian-12-qt6
-          - debian-12-tqt
+          - debian-13-core
+          - debian-13-gtk2
+          - debian-13-gtk3
+          - debian-13-qt5
+          - debian-13-qt6
+          - debian-13-tqt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/ci/dockerfiles/debian-13-core.dockerfile
+++ b/ci/dockerfiles/debian-13-core.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -9,31 +9,17 @@ RUN \
     /etc/apt/apt.conf.d/disable-install-recommends
 
 RUN \
-  echo 'deb http://mirror.ppa.trinitydesktop.org/trinity/deb/trinity-r14.1.x bookworm main deps' >> /etc/apt/sources.list
-
-ADD http://mirror.ppa.trinitydesktop.org/trinity/deb/trinity-keyring.deb /usr/local/
-
-RUN dpkg -i /usr/local/trinity-keyring.deb
-
-RUN \
   apt update -qq && \
   apt install -y \
-    cmake \
-    g++ \
     gcc \
     intltool \
     libedit-dev \
-    libtqt3-mt-dev \
     libncurses-dev \
-    libx11-dev \
-    libxft-dev \
     librsvg2-bin \
     make \
     pkg-config \
     ruby \
     sudo \
-    tdelibs14-trinity-dev \
-    tqt3-dev-tools \
     tzdata && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
@@ -50,4 +36,4 @@ USER uim
 RUN mkdir -p /home/uim/build
 WORKDIR /home/uim/build
 
-CMD /source/ci/build-tqt.sh
+CMD /source/ci/build-core.sh

--- a/ci/dockerfiles/debian-13-gtk2.dockerfile
+++ b/ci/dockerfiles/debian-13-gtk2.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -11,24 +11,15 @@ RUN \
 RUN \
   apt update -qq && \
   apt install -y \
-    cmake \
-    extra-cmake-modules \
-    g++ \
     gcc \
     intltool \
     libedit-dev \
-    libkf5plasma-dev \
+    libgtk2.0-bin \
+    libgtk2.0-dev \
     libncurses-dev \
-    libqt5x11extras5-dev \
     librsvg2-bin \
-    libx11-dev \
-    libxft-dev \
     make \
     pkg-config \
-    qt5-qmake \
-    qtbase5-dev \
-    qtbase5-private-dev \
-    qtdeclarative5-dev \
     ruby \
     sudo \
     tzdata && \
@@ -47,4 +38,4 @@ USER uim
 RUN mkdir -p /home/uim/build
 WORKDIR /home/uim/build
 
-CMD /source/ci/build-qt5.sh
+CMD /source/ci/build-gtk2.sh

--- a/ci/dockerfiles/debian-13-gtk3.dockerfile
+++ b/ci/dockerfiles/debian-13-gtk3.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -11,20 +11,15 @@ RUN \
 RUN \
   apt update -qq && \
   apt install -y \
-    cmake \
-    extra-cmake-modules \
-    g++ \
     gcc \
     intltool \
     libedit-dev \
+    libgtk-3-bin \
+    libgtk-3-dev \
     libncurses-dev \
     librsvg2-bin \
-    libx11-dev \
-    libxft-dev \
     make \
     pkg-config \
-    qt6-base-private-dev \
-    qt6-declarative-dev \
     ruby \
     sudo \
     tzdata && \
@@ -43,4 +38,4 @@ USER uim
 RUN mkdir -p /home/uim/build
 WORKDIR /home/uim/build
 
-CMD /source/ci/build-qt6.sh
+CMD /source/ci/build-gtk3.sh

--- a/ci/dockerfiles/debian-13-qt5.dockerfile
+++ b/ci/dockerfiles/debian-13-qt5.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -11,13 +11,24 @@ RUN \
 RUN \
   apt update -qq && \
   apt install -y \
+    cmake \
+    extra-cmake-modules \
+    g++ \
     gcc \
     intltool \
     libedit-dev \
+    libkf5plasma-dev \
     libncurses-dev \
+    libqt5x11extras5-dev \
     librsvg2-bin \
+    libx11-dev \
+    libxft-dev \
     make \
     pkg-config \
+    qt5-qmake \
+    qtbase5-dev \
+    qtbase5-private-dev \
+    qtdeclarative5-dev \
     ruby \
     sudo \
     tzdata && \
@@ -36,4 +47,4 @@ USER uim
 RUN mkdir -p /home/uim/build
 WORKDIR /home/uim/build
 
-CMD /source/ci/build-core.sh
+CMD /source/ci/build-qt5.sh

--- a/ci/dockerfiles/debian-13-qt6.dockerfile
+++ b/ci/dockerfiles/debian-13-qt6.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -11,15 +11,20 @@ RUN \
 RUN \
   apt update -qq && \
   apt install -y \
+    cmake \
+    extra-cmake-modules \
+    g++ \
     gcc \
     intltool \
     libedit-dev \
-    libgtk2.0-bin \
-    libgtk2.0-dev \
     libncurses-dev \
     librsvg2-bin \
+    libx11-dev \
+    libxft-dev \
     make \
     pkg-config \
+    qt6-base-private-dev \
+    qt6-declarative-dev \
     ruby \
     sudo \
     tzdata && \
@@ -38,4 +43,4 @@ USER uim
 RUN mkdir -p /home/uim/build
 WORKDIR /home/uim/build
 
-CMD /source/ci/build-gtk2.sh
+CMD /source/ci/build-qt6.sh

--- a/ci/dockerfiles/debian-13-tqt.dockerfile
+++ b/ci/dockerfiles/debian-13-tqt.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -9,19 +9,31 @@ RUN \
     /etc/apt/apt.conf.d/disable-install-recommends
 
 RUN \
+  echo "deb http://mirror.ppa.trinitydesktop.org/trinity/deb/trinity-r14.1.x $(. /etc/os-release; echo ${VERSION_CODENAME}) main deps" >> /etc/apt/sources.list
+
+ADD http://mirror.ppa.trinitydesktop.org/trinity/deb/trinity-keyring.deb /usr/local/
+
+RUN dpkg -i /usr/local/trinity-keyring.deb
+
+RUN \
   apt update -qq && \
   apt install -y \
+    cmake \
+    g++ \
     gcc \
     intltool \
     libedit-dev \
-    libgtk-3-bin \
-    libgtk-3-dev \
+    libtqt3-mt-dev \
     libncurses-dev \
+    libx11-dev \
+    libxft-dev \
     librsvg2-bin \
     make \
     pkg-config \
     ruby \
     sudo \
+    tdelibs14-trinity-dev \
+    tqt3-dev-tools \
     tzdata && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
@@ -38,4 +50,4 @@ USER uim
 RUN mkdir -p /home/uim/build
 WORKDIR /home/uim/build
 
-CMD /source/ci/build-gtk3.sh
+CMD /source/ci/build-tqt.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,39 +27,39 @@ services:
       dockerfile: arch-linux-tqt.dockerfile
     volumes:
       - .:/source:delegated
-  debian-12-core:
-    image: uim/uim-debian-12-core
+  debian-13-core:
+    image: uim/uim-debian-13-core
     build:
       context: ci/dockerfiles
-      dockerfile: debian-12-core.dockerfile
+      dockerfile: debian-13-core.dockerfile
     volumes:
       - .:/source:delegated
-  debian-12-gtk2:
-    image: uim/uim-debian-12-gtk2
+  debian-13-gtk2:
+    image: uim/uim-debian-13-gtk2
     build:
       context: ci/dockerfiles
-      dockerfile: debian-12-gtk2.dockerfile
+      dockerfile: debian-13-gtk2.dockerfile
     volumes:
       - .:/source:delegated
-  debian-12-gtk3:
-    image: uim/uim-debian-12-gtk3
+  debian-13-gtk3:
+    image: uim/uim-debian-13-gtk3
     build:
       context: ci/dockerfiles
-      dockerfile: debian-12-gtk3.dockerfile
+      dockerfile: debian-13-gtk3.dockerfile
     volumes:
       - .:/source:delegated
-  debian-12-qt5:
-    image: uim/uim-debian-12-qt5
+  debian-13-qt5:
+    image: uim/uim-debian-13-qt5
     build:
       context: ci/dockerfiles
-      dockerfile: debian-12-qt5.dockerfile
+      dockerfile: debian-13-qt5.dockerfile
     volumes:
       - .:/source:delegated
-  debian-12-qt6:
-    image: uim/uim-debian-12-qt6
+  debian-13-qt6:
+    image: uim/uim-debian-13-qt6
     build:
       context: ci/dockerfiles
-      dockerfile: debian-12-qt6.dockerfile
+      dockerfile: debian-13-qt6.dockerfile
     volumes:
       - .:/source:delegated
   debian-12-release:
@@ -69,10 +69,10 @@ services:
       dockerfile: debian-12-release.dockerfile
     volumes:
       - .:/source:delegated
-  debian-12-tqt:
-    image: uim/uim-debian-12-tqt
+  debian-13-tqt:
+    image: uim/uim-debian-13-tqt
     build:
       context: ci/dockerfiles
-      dockerfile: debian-12-tqt.dockerfile
+      dockerfile: debian-13-tqt.dockerfile
     volumes:
       - .:/source:delegated


### PR DESCRIPTION
It's the current stable.

If we use Debian 13 for release, we got the #221 error. We will revisit it later.