### PR TITLE
uim-fep: sync child pty winsize after installing signal handlers

### DIFF
--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -534,6 +534,13 @@ opt_end:
   init_escseq(&attr_uim);
   set_signal_handler();
 
+  /*
+   * A resize may happen after the child pty is created but before SIGWINCH
+   * handlers are installed. Run the normal SIGWINCH path once to avoid leaving
+   * the child pty with a stale winsize before entering the main loop.
+   */
+  sigwinch_handler();
+
   if (s_path_setmode[0] != '\0' && mkfifo(s_path_setmode, 0600) != -1) {
     s_setmode_fd = open(s_path_setmode, O_RDONLY | O_NONBLOCK);
 #ifndef __CYGWIN32__


### PR DESCRIPTION
## Summary

This PR fixes a startup race in `uim-fep` where the child pty can keep a stale window size if the parent tty is resized before `uim-fep` starts handling `SIGWINCH`.

`uim-fep` creates the child pty before installing signal handlers. If the parent tty size changes in that window, the `SIGWINCH` can be missed. As a result, the shell running inside the child pty can continue to report the old size via `stty size`.

This PR re-reads the current parent tty winsize after installing signal handlers and applies it to the child pty before entering the main loop.

## Problem

`uim-fep` currently does this during startup:

1. Read the current parent tty winsize with `get_winsize()`.
2. Create the child pty using that size.
3. Start the child command on the child pty.
4. Initialize uim-fep internals.
5. Install signal handlers.
6. Enter the main loop.

If the parent tty is resized between step 2 and step 5, `SIGWINCH` may be missed. In that case, the child pty is not updated until a later resize happens.

This can leave the child shell with a stale pty size.

## Fix

After `set_signal_handler()` is called, explicitly synchronize the child pty winsize once before entering the main loop.

The new startup sequence becomes:

1. Read initial winsize.
2. Create child pty.
3. Initialize uim-fep internals.
4. Install signal handlers.
5. Re-read current parent tty winsize.
6. Apply it to the child pty.
7. Enter the main loop.

This ensures that even if a resize was missed during startup, the child pty is corrected before normal operation begins.
