### PR TITLE
uim-fep: fix terminal size report calculations

### DIFF
--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -778,7 +778,7 @@ static ssize_t adjust_terminal_size_reports(char *buf, ssize_t len)
         unsigned int removed_rows = rows - g_win->ws_row;
 
         if (ypixels > 0) {
-          unsigned int cell_height = ypixels / rows;
+          unsigned int cell_height = ypixels / rows + (ypixels % rows != 0);
 
           if (cell_height > 0 && ypixels > cell_height * removed_rows) {
             adjusted_ypixels = ypixels - cell_height * removed_rows;
@@ -786,7 +786,7 @@ static ssize_t adjust_terminal_size_reports(char *buf, ssize_t len)
         }
         new_len = snprintf(replacement, sizeof(replacement),
                            "\033[48;%u;%u;%u;%ut",
-                           g_win->ws_row, cols, adjusted_ypixels, xpixels);
+                           (unsigned int)g_win->ws_row, cols, adjusted_ypixels, xpixels);
         adjusted = TRUE;
       }
     } else if (sscanf(p, "\033[4;%u;%ut%n", &ypixels, &xpixels, &old_len) == 2 &&
@@ -799,7 +799,7 @@ static ssize_t adjust_terminal_size_reports(char *buf, ssize_t len)
        */
       if (ypixels > 0) {
         unsigned int real_rows = g_win->ws_row + 1;
-        unsigned int cell_height = ypixels / real_rows;
+        unsigned int cell_height = ypixels / real_rows + (ypixels % real_rows != 0);
         unsigned int adjusted_ypixels = ypixels;
 
         if (cell_height > 0 && ypixels > cell_height) {
@@ -814,7 +814,7 @@ static ssize_t adjust_terminal_size_reports(char *buf, ssize_t len)
       /* xterm-style text area size report: CSI 8 ; rows ; cols t. */
       if (rows > g_win->ws_row) {
         new_len = snprintf(replacement, sizeof(replacement),
-                           "\033[8;%u;%ut", g_win->ws_row, cols);
+                           "\033[8;%u;%ut", (unsigned int)g_win->ws_row, cols);
         adjusted = TRUE;
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #287.

This PR addresses review comments on terminal size report adjustment in
`LASTLINE` mode.

## Changes

- Use ceiling division when estimating cell height for the `CSI 48`
  in-band resize notification.
- Use ceiling division when estimating cell height for the `CSI 4`
  text-area pixel-size response.
- Cast `g_win->ws_row` to `unsigned int` when formatting `CSI 48` and
  `CSI 8` reports with `%u`.

Using ceiling division ensures that the forwarded pixel height fully
excludes the bottom row reserved for the uim-fep status line when the
reported pixel height is not evenly divisible by the row count.

The explicit casts make the variadic arguments passed to `snprintf()`
match the `%u` conversion specifier.
