### PR TITLE
uim: fix parallel plugin installation

### DIFF
--- a/uim/Makefile.am
+++ b/uim/Makefile.am
@@ -37,6 +37,11 @@ noinst_LTLIBRARIES += libuim-counted-init.la
 uim_plugin_LTLIBRARIES = 
 uim_plugindir = $(pkglibdir)/plugin
 
+# Libtool relinks plugins against libraries in $(libdir) when installing
+# them. Ensure that the core libraries are installed before the plugins
+# when make install is run in parallel.
+install-uim_pluginLTLIBRARIES: install-libLTLIBRARIES
+
 BUILT_SOURCES = sigscheme-combined
 .PHONY: sigscheme-combined
 sigscheme-combined:


### PR DESCRIPTION
## Summary
Fix a dependency issue that can cause parallel `make install` to fail
while installing uim plugins.
## Problem
During installation, libtool relinks uim plugins against the installed
core libraries.
With a parallel installation such as:
```
make install -j24
```
plugin relinking could start before `libuim-scm` and `libuim` had been
installed. This caused the linker to fail with errors such as:
```
cannot find -luim-scm
cannot find -luim
```
A serial installation did not reproduce this failure because the core
libraries were installed before the plugins.
## Changes
Make the plugin installation target depend on installation of the core
libraries:
```make
install-uim_pluginLTLIBRARIES: install-libLTLIBRARIES
```
This ensures that `libuim-scm`, `libuim`, and the other core libraries
are installed before libtool relinks and installs the plugins.
