### PR TITLE
uim-fep: preserve the preedit cursor during terminal updates

### DIFF
--- a/fep/draw.c
+++ b/fep/draw.c
@@ -116,6 +116,23 @@ static struct point_tag width2point_col(int width);
 static int width2lineno_char(int width);
 static int width2lineno_col(int width);
 
+/*
+ * Return the current on-screen preedit cursor position.
+ */
+int get_preedit_cursor_position(int *row, int *col)
+{
+  struct point_tag dest;
+
+  if (!g_start_preedit || g_opt.no_report_cursor) {
+    return FALSE;
+  }
+
+  dest = width2point_char(s_preedit->cursor);
+  *row = dest.row;
+  *col = dest.col;
+  return TRUE;
+}
+
 #if defined(DEBUG) && DEBUG > 2
 static void print_preedit(struct preedit_tag *p);
 #endif

--- a/fep/draw.h
+++ b/fep/draw.h
@@ -57,5 +57,6 @@ void clear_backtick(void);
 int is_commit_and_preedit(void);
 void draw_commit_and_preedit(void);
 void draw_winch(struct winsize *prevwin);
+int get_preedit_cursor_position(int *row, int *col);
 
 #endif

--- a/fep/escseq.c
+++ b/fep/escseq.c
@@ -1222,7 +1222,9 @@ void put_pty_str(const char *str, int len)
   set_attr(str, len);
   g_commit = FALSE;
   s_cursor.row = s_cursor.col = UNDEFINED;
-  debug(("<put_pty_str \"%s\">", str));
+  debug(("<put_pty_str \""));
+  debug_write(str, len);
+  debug(("\">\n"));
 }
 
 

--- a/fep/read.c
+++ b/fep/read.c
@@ -81,14 +81,15 @@ int my_select(int n, fd_set *readfds, struct timeval *timeout)
  * pselect
  * ungetがあるときはpselectを呼ばない. 
  */
-int my_pselect(int n, fd_set *readfds, const sigset_t *sigmask)
+int my_pselect(int n, fd_set *readfds, const struct timespec *timeout,
+               const sigset_t *sigmask)
 {
   if (s_buf_size > 0) {
     FD_ZERO(readfds);
     FD_SET(g_win_in, readfds);
     return 1;
   }
-  return pselect_(n, readfds, NULL, NULL, NULL, sigmask);
+  return pselect_(n, readfds, NULL, NULL, timeout, sigmask);
 }
 
 /*
@@ -133,6 +134,14 @@ static int pselect_(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
   int ret;
   sigset_t orig_sigmask;
   sigset_t pending_signals;
+  struct timeval select_timeout;
+  struct timeval *select_timeout_ptr = NULL;
+
+  if (timeout != NULL) {
+    select_timeout.tv_sec = timeout->tv_sec;
+    select_timeout.tv_usec = timeout->tv_nsec / 1000;
+    select_timeout_ptr = &select_timeout;
+  }
 
   /* シグナルが保留されているか */
   sigpending(&pending_signals);
@@ -153,9 +162,8 @@ static int pselect_(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
     return -1;
   }
 
-  /* timeout は使わない */
   sigprocmask(SIG_SETMASK, sigmask, &orig_sigmask);
-  ret = select(n, readfds, writefds, exceptfds, NULL);
+  ret = select(n, readfds, writefds, exceptfds, select_timeout_ptr);
   sigprocmask(SIG_SETMASK, &orig_sigmask, NULL);
   return ret;
 }

--- a/fep/read.h
+++ b/fep/read.h
@@ -46,9 +46,11 @@
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#include <time.h>
 
 int my_select(int n, fd_set *readfds, struct timeval *timeout);
-int my_pselect(int n, fd_set *readfds, const sigset_t *sigmask);
+int my_pselect(int n, fd_set *readfds, const struct timespec *timeout,
+               const sigset_t *sigmask);
 ssize_t read_stdin(void *buf, int count);
 void unget_stdin(const char *str, int count);
 

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -849,6 +849,7 @@ static int s_cursor_hidden;
 static struct timespec s_pending_pty_sequence_deadline;
 
 enum tracked_pty_sequence_id {
+  PTY_SEQUENCE_UNKNOWN = -1,
   PTY_SEQUENCE_SYNC_BEGIN,
   PTY_SEQUENCE_SYNC_END,
   PTY_SEQUENCE_CURSOR_HIDE,
@@ -882,8 +883,8 @@ static int pending_pty_sequence_is_prefix(void)
   return FALSE;
 }
 
-/* Return the ID of a completed tracked sequence, or -1 if incomplete. */
-static int completed_pty_sequence(void)
+/* Return the ID of a completed tracked sequence, or UNKNOWN if incomplete. */
+static enum tracked_pty_sequence_id completed_pty_sequence(void)
 {
   size_t i;
 
@@ -893,7 +894,7 @@ static int completed_pty_sequence(void)
       return s_tracked_pty_sequences[i].id;
     }
   }
-  return -1;
+  return PTY_SEQUENCE_UNKNOWN;
 }
 
 /* Move the terminal cursor to the current on-screen preedit position. */
@@ -1002,12 +1003,12 @@ static void filter_pty_output(const char *buf, ssize_t len)
     }
 
     if (s_pending_pty_sequence_len < sizeof(s_pending_pty_sequence)) {
-      int sequence;
+      enum tracked_pty_sequence_id sequence;
 
       s_pending_pty_sequence[s_pending_pty_sequence_len++] = buf[i++];
       sequence = completed_pty_sequence();
-      if (sequence >= 0) {
-        output_completed_pty_sequence((enum tracked_pty_sequence_id)sequence);
+      if (sequence != PTY_SEQUENCE_UNKNOWN) {
+        output_completed_pty_sequence(sequence);
       } else if (!pending_pty_sequence_is_prefix()) {
         char pending[PTY_SEQUENCE_MAX];
         size_t pending_len = s_pending_pty_sequence_len;

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -89,6 +89,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+#include <time.h>
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif
@@ -170,6 +171,8 @@ static int make_color_escseq(const char *instr, struct attribute_tag *attr);
 static int colorname2n(const char *name);
 static pid_t my_forkpty(int *amaster, struct termios *termp, struct winsize *winp);
 static ssize_t adjust_terminal_size_reports(char *buf, ssize_t len);
+static void filter_pty_output(const char *buf, ssize_t len);
+static void flush_pending_pty_sequence(void);
 static void main_loop(void);
 static void recover_loop(void);
 static struct winsize *get_winsize(void);
@@ -833,6 +836,193 @@ static ssize_t adjust_terminal_size_reports(char *buf, ssize_t len)
   return len;
 }
 
+#define NSEC_PER_MSEC (1000L * 1000L)
+#define NSEC_PER_SEC (1000L * 1000L * 1000L)
+#define PTY_SEQUENCE_TIMEOUT_MSEC 20L
+#define PTY_SEQUENCE_TIMEOUT_NSEC (PTY_SEQUENCE_TIMEOUT_MSEC * NSEC_PER_MSEC)
+#define PTY_SEQUENCE_MAX 8
+
+static char s_pending_pty_sequence[PTY_SEQUENCE_MAX];
+static size_t s_pending_pty_sequence_len;
+static int s_synchronized_update;
+static int s_cursor_hidden;
+static struct timespec s_pending_pty_sequence_deadline;
+
+enum tracked_pty_sequence_id {
+  PTY_SEQUENCE_SYNC_BEGIN,
+  PTY_SEQUENCE_SYNC_END,
+  PTY_SEQUENCE_CURSOR_HIDE,
+  PTY_SEQUENCE_CURSOR_SHOW
+};
+
+struct tracked_pty_sequence {
+  const char *str;
+  size_t len;
+  enum tracked_pty_sequence_id id;
+};
+
+static const struct tracked_pty_sequence s_tracked_pty_sequences[] = {
+  { "\033[?2026h", 8, PTY_SEQUENCE_SYNC_BEGIN },  /* Begin synchronized output. */
+  { "\033[?2026l", 8, PTY_SEQUENCE_SYNC_END },    /* End synchronized output. */
+  { "\033[?25l", 6, PTY_SEQUENCE_CURSOR_HIDE },  /* Hide the cursor. */
+  { "\033[?25h", 6, PTY_SEQUENCE_CURSOR_SHOW }   /* Show the cursor. */
+};
+
+/* Return whether the pending bytes can still form a tracked sequence. */
+static int pending_pty_sequence_is_prefix(void)
+{
+  size_t i;
+
+  for (i = 0; i < sizeof(s_tracked_pty_sequences) / sizeof(s_tracked_pty_sequences[0]); i++) {
+    if (s_pending_pty_sequence_len <= s_tracked_pty_sequences[i].len &&
+        memcmp(s_pending_pty_sequence, s_tracked_pty_sequences[i].str, s_pending_pty_sequence_len) == 0) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/* Return the ID of a completed tracked sequence, or -1 if incomplete. */
+static int completed_pty_sequence(void)
+{
+  size_t i;
+
+  for (i = 0; i < sizeof(s_tracked_pty_sequences) / sizeof(s_tracked_pty_sequences[0]); i++) {
+    if (s_pending_pty_sequence_len == s_tracked_pty_sequences[i].len &&
+        memcmp(s_pending_pty_sequence, s_tracked_pty_sequences[i].str, s_pending_pty_sequence_len) == 0) {
+      return s_tracked_pty_sequences[i].id;
+    }
+  }
+  return -1;
+}
+
+/* Move the terminal cursor to the current on-screen preedit position. */
+static void restore_preedit_cursor(void)
+{
+  int row, col;
+
+  if (get_preedit_cursor_position(&row, &col)) {
+    put_cursor_address(row, col);
+  }
+}
+
+/* Update the tracked terminal state and output a completed sequence. */
+static void output_completed_pty_sequence(enum tracked_pty_sequence_id sequence)
+{
+  int was_protected = s_synchronized_update || s_cursor_hidden;
+  int will_be_protected;
+
+  switch (sequence) {
+  case PTY_SEQUENCE_SYNC_BEGIN:
+    s_synchronized_update = TRUE;
+    break;
+  case PTY_SEQUENCE_SYNC_END:
+    s_synchronized_update = FALSE;
+    break;
+  case PTY_SEQUENCE_CURSOR_HIDE:
+    s_cursor_hidden = TRUE;
+    break;
+  case PTY_SEQUENCE_CURSOR_SHOW:
+    s_cursor_hidden = FALSE;
+    break;
+  }
+
+  will_be_protected = s_synchronized_update || s_cursor_hidden;
+  if (was_protected && !will_be_protected) {
+    restore_preedit_cursor();
+  }
+
+  put_pty_str(s_pending_pty_sequence, s_pending_pty_sequence_len);
+  s_pending_pty_sequence_len = 0;
+}
+
+/* Output an incomplete pending sequence unchanged and clear it. */
+static void flush_pending_pty_sequence(void)
+{
+  if (s_pending_pty_sequence_len > 0) {
+    put_pty_str(s_pending_pty_sequence, s_pending_pty_sequence_len);
+    s_pending_pty_sequence_len = 0;
+  }
+}
+
+/* Set the fixed deadline for completing a newly pending sequence. */
+static void start_pending_pty_sequence(void)
+{
+  clock_gettime(CLOCK_MONOTONIC, &s_pending_pty_sequence_deadline);
+  s_pending_pty_sequence_deadline.tv_nsec += PTY_SEQUENCE_TIMEOUT_NSEC;
+  if (s_pending_pty_sequence_deadline.tv_nsec >= NSEC_PER_SEC) {
+    s_pending_pty_sequence_deadline.tv_sec++;
+    s_pending_pty_sequence_deadline.tv_nsec -= NSEC_PER_SEC;
+  }
+}
+
+/* Return whether the pending sequence expired and report time remaining. */
+static int pending_pty_sequence_timeout(struct timespec *remaining)
+{
+  struct timespec now;
+
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  remaining->tv_sec = s_pending_pty_sequence_deadline.tv_sec - now.tv_sec;
+  remaining->tv_nsec = s_pending_pty_sequence_deadline.tv_nsec - now.tv_nsec;
+  if (remaining->tv_nsec < 0) {
+    remaining->tv_sec--;
+    remaining->tv_nsec += NSEC_PER_SEC;
+  }
+  if (remaining->tv_sec < 0 ||
+      (remaining->tv_sec == 0 && remaining->tv_nsec == 0)) {
+    remaining->tv_sec = 0;
+    remaining->tv_nsec = 0;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/* Track selected control sequences while forwarding child PTY output. */
+static void filter_pty_output(const char *buf, ssize_t len)
+{
+  ssize_t i = 0;
+
+  while (i < len) {
+    if (s_pending_pty_sequence_len == 0) {
+      const char *escape = memchr(buf + i, ESCAPE_CODE, len - i);
+      ssize_t text_len;
+
+      if (escape == NULL) {
+        put_pty_str(buf + i, len - i);
+        return;
+      }
+      text_len = escape - (buf + i);
+      if (text_len > 0) {
+        put_pty_str(buf + i, text_len);
+        i += text_len;
+      }
+      s_pending_pty_sequence[s_pending_pty_sequence_len++] = buf[i++];
+      start_pending_pty_sequence();
+      continue;
+    }
+
+    if (s_pending_pty_sequence_len < sizeof(s_pending_pty_sequence)) {
+      int sequence;
+
+      s_pending_pty_sequence[s_pending_pty_sequence_len++] = buf[i++];
+      sequence = completed_pty_sequence();
+      if (sequence >= 0) {
+        output_completed_pty_sequence((enum tracked_pty_sequence_id)sequence);
+      } else if (!pending_pty_sequence_is_prefix()) {
+        char pending[PTY_SEQUENCE_MAX];
+        size_t pending_len = s_pending_pty_sequence_len;
+
+        memcpy(pending, s_pending_pty_sequence, pending_len);
+        s_pending_pty_sequence_len = 0;
+        put_pty_str(pending, 1);
+        filter_pty_output(pending + 1, pending_len - 1);
+      }
+    } else {
+      flush_pending_pty_sequence();
+    }
+  }
+}
+
 #define BUFSIZE 4096
 static void main_loop(void)
 {
@@ -863,6 +1053,10 @@ static void main_loop(void)
   nfd++;
 
   while (TRUE) {
+    struct timespec timeout;
+    const struct timespec *timeout_ptr = NULL;
+    int selected;
+
     /* コミットされたときにプリエディットがあるか */
     if (is_commit_and_preedit()) {
       struct timeval t;
@@ -892,7 +1086,21 @@ static void main_loop(void)
       FD_SET(g_helper_fd, &fds);
     }
 
-    if (my_pselect(nfd, &fds, &s_orig_sigmask) <= 0) {
+    /* Use the pending sequence deadline as the next pselect timeout. */
+    if (s_pending_pty_sequence_len > 0) {
+      if (pending_pty_sequence_timeout(&timeout)) {
+        flush_pending_pty_sequence();
+        continue;
+      }
+      timeout_ptr = &timeout;
+    }
+
+    selected = my_pselect(nfd, &fds, timeout_ptr, &s_orig_sigmask);
+    if (selected == 0) {
+      flush_pending_pty_sequence();
+      continue;
+    }
+    if (selected < 0) {
       /* signalで割り込まれたときにくる。selectの返り値は-1でerrno==EINTR */
       debug(("signal flag = %x\n", s_signal_flag));
       if ((s_signal_flag & SIG_FLAG_DONE   ) != 0) {
@@ -1087,6 +1295,7 @@ static void main_loop(void)
     if (!g_opt.print_key && FD_ISSET(s_master, &fds)) {
       if ((len = read(s_master, buf, sizeof(buf) - 1)) == -1 || len == 0) {
         /* 子プロセスが終了した */
+        flush_pending_pty_sequence();
         return;
       }
       buf[len] = '\0';
@@ -1102,14 +1311,14 @@ static void main_loop(void)
           }
           str1_len = len - (str1 - buf);
           /* str1はclear_screenかclr_eosの次の文字列を指している */
-          put_pty_str(buf, len - str1_len);
+          filter_pty_output(buf, len - str1_len);
           draw_statusline_force_restore();
-          put_pty_str(str1, str1_len);
+          filter_pty_output(str1, str1_len);
         } else {
-          put_pty_str(buf, len);
+          filter_pty_output(buf, len);
         }
       } else {
-        put_pty_str(buf, len);
+        filter_pty_output(buf, len);
       }
     }
 
@@ -1319,6 +1528,7 @@ static void sigwinch_handler(void)
 
 void done(int exit_value)
 {
+  flush_pending_pty_sequence();
   uim_quit();
   quit_escseq();
   quit_helper();


### PR DESCRIPTION
## Summary
Keep the terminal cursor at the current on-screen preedit position while
a child application updates the terminal.
## Problem
A child application does not know that uim-fep is displaying preedit
text over its input position. When the application redraws the screen,
it may restore the terminal cursor to its own logical input position,
which corresponds to the beginning of the preedit.
As a result, the visible cursor can move from the current position
inside the preedit back to the preedit head.
This was observed with applications using different update strategies:
- Neovim uses synchronized terminal updates while redrawing parts of
  the screen.
- GitHub Copilot CLI hides the cursor while updating its spinner or
  streaming output and shows it again when the update is complete.
## Changes
- Add a helper that returns the current on-screen preedit cursor
  position.
- Track the following terminal states in child pty output:
  - Synchronized update mode, `CSI ? 2026 h` and `CSI ? 2026 l`
  - Cursor visibility, `CSI ? 25 l` and `CSI ? 25 h`
- Treat synchronized updates and hidden-cursor periods as protected
  update states.
- Restore the preedit cursor immediately before the last protected
  state ends.
- Preserve tracked escape-sequence prefixes across pty reads.
- Flush an incomplete tracked sequence unchanged after a short timeout.
- Extend `my_pselect()` to accept a timeout so that normal waiting,
  signal handling, and incomplete-sequence waiting use the same path.
## Behavior
For an application using synchronized updates:
```
CSI ? 2026 h
screen update
cursor movement
CUP to the current preedit position
CSI ? 2026 l
```
The cursor correction remains inside the synchronized update, so the
intermediate cursor position is not presented to the user.
For an application hiding the cursor:
```
CSI ? 25 l
screen update
cursor movement
CUP to the current preedit position
CSI ? 25 h
```
The cursor is restored before it becomes visible.
If synchronized updates and cursor hiding overlap, uim-fep waits until
both states have ended. This prevents an unnecessary correction while
the cursor is still hidden or while a synchronized update is still in
progress.
## Split escape sequences
A tracked control sequence may be divided across multiple pty reads.
For example:
```
read 1: ESC [ ? 20
read 2: 26 h
```
uim-fep temporarily buffers only prefixes that can become one of the
tracked sequences. Once a sequence is complete, uim-fep updates the
tracked state and outputs the sequence.
If the buffered bytes no longer match a tracked prefix, they are
forwarded unchanged immediately. If a prefix remains incomplete, it is
forwarded unchanged after a 20-millisecond timeout.