### PR TITLE
uim-fep: fix SETMODE race when a commit and new preedit overlap

### DIFF
--- a/fep/draw.c
+++ b/fep/draw.c
@@ -325,6 +325,16 @@ int is_commit_and_preedit(void)
 }
 
 /*
+ * Return TRUE if a new preedit started with a commit is still waiting to
+ * be shown by draw_commit_and_preedit(). Unlike is_commit_and_preedit(),
+ * this is TRUE even before g_commit is reset.
+ */
+int has_pending_preedit(void)
+{
+  return s_save_preedit.width > 0;
+}
+
+/*
  * is_commit_and_preedit() == TRUEのときに呼ばれ，
  * プリエディットを出力する
  */

--- a/fep/draw.h
+++ b/fep/draw.h
@@ -56,6 +56,7 @@ void clear_lastline(void);
 void clear_backtick(void);
 int is_commit_and_preedit(void);
 void draw_commit_and_preedit(void);
+int has_pending_preedit(void);
 void draw_winch(struct winsize *prevwin);
 int get_preedit_cursor_position(int *row, int *col);
 

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -1150,8 +1150,12 @@ static void main_loop(void)
 #endif
 
       for (end = len - 1; end >= 0 && !isdigit((unsigned char)buf[end]); --end);
-      /* プリエディットを編集中でなければモードを変更する */
-      if (end >= 0 && !g_start_preedit) {
+      /*
+       * Change the mode unless a preedit is being edited. has_pending_preedit()
+       * is also checked because a preedit that starts together with a commit
+       * is not yet reflected in g_start_preedit or is_commit_and_preedit().
+       */
+      if (end >= 0 && !g_start_preedit && !has_pending_preedit()) {
         int mode;
 
         for (start = end; start > 0 && isdigit((unsigned char)buf[start - 1]); --start);


### PR DESCRIPTION
## Summary
Fix a race that could leave uim-fep in an inconsistent state (mode 0 with a preedit still effectively active) when a commit and a new preedit start at the same time.

## Problem
Sometimes a commit and a new preedit start happen at the same time — for example, SKK confirms a word and immediately starts a new conversion. In this case, the new preedit is not shown right away; it waits until `draw_commit_and_preedit()` runs. Until then, `g_start_preedit` stays `FALSE` even though a preedit already exists in practice. `is_commit_and_preedit()`, which is meant to detect this case, also stays `FALSE` until `g_commit` is reset, which only happens after the child process echoes the commit back through the pty.

During this short window, if something writes to the SETMODE fifo asynchronously (for example, an editor plugin that switches SKK's mode), the existing `!g_start_preedit` check does not catch it, so the mode can be changed to mode 0 (latin, plain passthrough) while the preedit is effectively still active. SKK normally never has an active preedit while in mode 0, so this leaves uim-fep in a state it does not expect, breaking further key handling until the process is restarted.

## Changes
- Add `has_pending_preedit()`, which checks directly whether a new preedit is pending (independent of the `g_commit`/echo timing above).
- Use it together with `g_start_preedit` to guard the SETMODE handling.