### PR TITLE
qt6: require C++17 for qmake projects

### DIFF
--- a/qt6/candwin/uim-candwin-qt6.pro.in
+++ b/qt6/candwin/uim-candwin-qt6.pro.in
@@ -1,6 +1,7 @@
 include(../../qt4/common.pro)
 
 TEMPLATE = app
+CONFIG += c++17
 
 # to include qtgettext.h
 INCLUDEPATH += @srcdir@/../../qt4

--- a/qt6/chardict/uim-chardict-qt6.pro.in
+++ b/qt6/chardict/uim-chardict-qt6.pro.in
@@ -1,5 +1,7 @@
 include(../../qt4/common.pro)
 
+CONFIG += c++17
+
 # to include qtgettext.h
 INCLUDEPATH += @srcdir@/../../qt4
 LIBS += @LIBINTL@ @X11_LIBS@

--- a/qt6/immodule/quimplatforminputcontextplugin.pro.in
+++ b/qt6/immodule/quimplatforminputcontextplugin.pro.in
@@ -2,6 +2,7 @@ include(../../qt4/common.pro)
 
 TEMPLATE = lib
 CONFIG += plugin
+CONFIG += c++17
 
 # to include util.h and for quimplatforminputcontext.cpp
 INCLUDEPATH += @srcdir@/../../qt4/candwin \

--- a/qt6/pref/uim-pref-qt6.pro.in
+++ b/qt6/pref/uim-pref-qt6.pro.in
@@ -1,6 +1,7 @@
 include(../../qt4/common.pro)
 
 TEMPLATE = app
+CONFIG += c++17
 
 # to include qtgettext.h
 INCLUDEPATH += @srcdir@/../../qt4

--- a/qt6/switcher/uim-im-switcher-qt6.pro.in
+++ b/qt6/switcher/uim-im-switcher-qt6.pro.in
@@ -1,6 +1,7 @@
 include(../../qt4/common.pro)
 
 TEMPLATE = app
+CONFIG += c++17
 
 # to include qtgettext.h
 INCLUDEPATH += @srcdir@/../../qt4

--- a/qt6/toolbar/uim-toolbar-qt6.pro.in
+++ b/qt6/toolbar/uim-toolbar-qt6.pro.in
@@ -1,6 +1,7 @@
 include(../../qt4/common.pro)
 
 TEMPLATE = app
+CONFIG += c++17
 
 # to include qtgettext.h
 INCLUDEPATH += @srcdir@/../../qt4


### PR DESCRIPTION
## Summary

Explicitly require C++17 in all Qt6 qmake projects.

## Background

With GCC 16, C++20 is the default language standard. The C++11 feature test generated by Autoconf 2.72 is incompatible with C++20's `char8_t` behavior, so it selects `-std=gnu++11`. That flag is propagated through `QMAKE_CXX` in `qt4/common.pro` and causes the Qt6 build to use C++11, although Qt6 requires C++17 or newer.

Adding `CONFIG += c++17` to each Qt6 qmake project makes the required standard explicit and avoids depending on the standard selected by Autoconf.

## Testing

- `docker compose build arch-linux-qt6`
- `docker compose run --rm arch-linux-qt6`

The Arch Linux Qt6 build completed successfully after this change.
