### PR TITLE
uim-fep: fix OOB write in make_page_strs when a first candidate overflows the page

### DIFF
--- a/fep/callbacks.c
+++ b/fep/callbacks.c
@@ -842,6 +842,7 @@ static void make_page_strs(void)
         /* はみ出たが、次に移さない */
         assert(page_width == 0);
         next = TRUE;
+        add_extra_page = TRUE; /* ページを閉じて1つ消費するので、次ページを確保する */
                                                   /* 全角1文字の幅 */
         if (s_max_width >= cand_label_width + (int)strlen(":") + 2 + (int)strlen(" ") + index_width) {
           /* 候補 + インデックス */
@@ -887,6 +888,8 @@ static void make_page_strs(void)
     }
 
     if (next) { /* do fix the page */
+      /* 不変条件: 書き込み前に page は常に nr_pages 未満 (assert は NDEBUG で無効) */
+      assert(page < s_candidate.nr_pages);
       if (index_width == UNDEFINED) {
         s_candidate.index_col[page] = UNDEFINED;
       } else {

--- a/fep/callbacks.c
+++ b/fep/callbacks.c
@@ -842,7 +842,9 @@ static void make_page_strs(void)
         /* はみ出たが、次に移さない */
         assert(page_width == 0);
         next = TRUE;
-        add_extra_page = TRUE; /* ページを閉じて1つ消費するので、次ページを確保する */
+        if (index + 1 - start < nr_in_virtual_page) {
+          add_extra_page = TRUE; /* 後続候補を表示するため次ページを確保する */
+        }
                                                   /* 全角1文字の幅 */
         if (s_max_width >= cand_label_width + (int)strlen(":") + 2 + (int)strlen(" ") + index_width) {
           /* 候補 + インデックス */

--- a/fep/callbacks.c
+++ b/fep/callbacks.c
@@ -890,8 +890,6 @@ static void make_page_strs(void)
     }
 
     if (next) { /* do fix the page */
-      /* 不変条件: 書き込み前に page は常に nr_pages 未満 (assert は NDEBUG で無効) */
-      assert(page < s_candidate.nr_pages);
       if (index_width == UNDEFINED) {
         s_candidate.index_col[page] = UNDEFINED;
       } else {


### PR DESCRIPTION
## Summary

`make_page_strs()` in `fep/callbacks.c` can write past the end of the candidate page arrays (`s_candidate.index_col[]` / `s_candidate.page_strs[]`), corrupting the heap. uim-fep then aborts with `realloc(): invalid next size` (SIGABRT).

## Problem

`make_page_strs()` writes to `s_candidate.index_col[page]` and `s_candidate.page_strs[page]` without checking that `page < s_candidate.nr_pages`.

When the first candidate of a page is wider than the page width (the `index_in_page == 0` branch at line 841), the code sets `next = TRUE` but does **not** set `add_extra_page`. `page` is then incremented past `nr_pages`, and the following writes in the `if (next)` block overflow the arrays. The corruption is detected later by the allocator as `realloc(): invalid next size`, aborting uim-fep with SIGABRT.

A 2013 change (f71ef2d0) only guarded the free side and did not fix this write path.

### Reproducer

When the mozc history contains an oversized candidate (91 columns or wider), sending the SGR mouse sequence `ESC[<0;50;50M` while the candidate list is displayed crashes uim-fep. Under AddressSanitizer:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 4
    #0 make_page_strs /tmp/uim-src/fep/callbacks.c:906
SUMMARY: AddressSanitizer: heap-buffer-overflow fep/callbacks.c:906 in make_page_strs
```

## Changes

- In the `index_in_page == 0` branch (line 841), set `add_extra_page = TRUE` so that `page` and `nr_pages` advance together and the page arrays stay in sync.

## Verification

Tested with uim-fep 1.9.6 built with AddressSanitizer and an isolated mozc profile containing the oversized-candidate history:

- **Before the fix:** `heap-buffer-overflow` (WRITE of size 4) at `fep/callbacks.c:906` in `make_page_strs` → SIGABRT
- **After the fix:** no crash; the SGR mouse sequence is handled normally and uim-fep exits gracefully
