### PR TITLE
Recover uim-fep after fatal libuim errors

### DIFF
--- a/fep/draw.c
+++ b/fep/draw.c
@@ -650,6 +650,22 @@ void draw_statusline_force_restore(void)
 }
 
 /*
+ * Erase the display state owned by uim-fep before switching to transparent
+ * recovery mode.
+ */
+void recover_display(void)
+{
+  if (g_start_preedit) {
+    erase_preedit();
+    end_preedit();
+  }
+
+  if (g_opt.status_type == BACKTICK) {
+    clear_backtick();
+  }
+}
+
+/*
  * 最下行を消す
  * カーソルは最下行に移動する
  */

--- a/fep/draw.c
+++ b/fep/draw.c
@@ -108,6 +108,7 @@ static int compare_preedit_rev(struct preedit_tag *p1, struct preedit_tag *p2);
 static int min(int a, int b);
 static void erase_prev_preedit(void);
 static void erase_preedit(void);
+static void erase_displayed_preedit(const struct preedit_tag *preedit);
 static void set_line2width(struct preedit_tag *preedit);
 static void goto_char(int width);
 static void goto_col(int width);
@@ -219,17 +220,7 @@ int draw(void)
     /* プリエディットを消す必要があるか */
     if (prev_preedit->width > 0) {
       put_cursor_invisible();
-      if (g_opt.no_report_cursor) {
-        put_cursor_left(prev_preedit->cursor);
-        if (g_opt.on_the_spot) {
-          put_delete(prev_preedit->width);
-        } else {
-          put_erase(prev_preedit->width);
-          put_cursor_left(prev_preedit->width);
-        }
-      } else {
-        erase_preedit();
-      }
+      erase_displayed_preedit(prev_preedit);
       end_preedit();
     }
     write(s_master, commit_str, strlen(commit_str));
@@ -656,8 +647,10 @@ void draw_statusline_force_restore(void)
 void recover_display(void)
 {
   if (g_start_preedit) {
-    erase_preedit();
+    put_cursor_invisible();
+    erase_displayed_preedit(s_preedit);
     end_preedit();
+    put_cursor_normal();
   }
 
   if (g_opt.status_type == BACKTICK) {
@@ -1021,6 +1014,21 @@ static void erase_preedit(void)
   s_line2width = uim_malloc(sizeof(int));
   s_line2width[0] = s_head.col;
   erase_prev_preedit();
+}
+
+static void erase_displayed_preedit(const struct preedit_tag *preedit)
+{
+  if (g_opt.no_report_cursor) {
+    put_cursor_left(preedit->cursor);
+    if (g_opt.on_the_spot) {
+      put_delete(preedit->width);
+    } else {
+      put_erase(preedit->width);
+      put_cursor_left(preedit->width);
+    }
+  } else {
+    erase_preedit();
+  }
 }
 
 static void set_line2width(struct preedit_tag *preedit)

--- a/fep/draw.c
+++ b/fep/draw.c
@@ -148,6 +148,21 @@ void init_draw(int master, const char *path_getmode)
   }
 }
 
+void write_getmode(int mode)
+{
+  FILE *fp;
+
+  if (s_path_getmode == NULL || s_path_getmode[0] == '\0') {
+    return;
+  }
+
+  fp = fopen(s_path_getmode, "wt");
+  if (fp != NULL) {
+    fprintf(fp, "%d\n", mode);
+    fclose(fp);
+  }
+}
+
 static void init_backtick(void)
 {
   if (getenv("WINDOW")) {
@@ -524,14 +539,7 @@ end_candidate:
   if (force || strcmp(mode_str, prev_mode_str) != 0) {
 
     /* 現在のモードをUIM_FEP_GETMODEに書き込む */
-    if (s_path_getmode[0] != '\0') {
-      FILE *fp = fopen(s_path_getmode, "wt");
-      if (fp) {
-        int mode = get_mode();
-        fprintf(fp, "%d\n", mode);
-        fclose(fp);
-      }
-    }
+    write_getmode(get_mode());
 
     if (g_opt.status_type != NONE && statusline_str[0] == '\0') {
       if (g_opt.status_type == LASTLINE) {

--- a/fep/draw.h
+++ b/fep/draw.h
@@ -52,6 +52,7 @@ int draw(void);
 void draw_statusline_restore(void);
 void draw_statusline_force_no_restore(void);
 void draw_statusline_force_restore(void);
+void recover_display(void);
 void clear_lastline(void);
 void clear_backtick(void);
 int is_commit_and_preedit(void);

--- a/fep/draw.h
+++ b/fep/draw.h
@@ -47,6 +47,7 @@ extern int g_start_preedit;
 extern int g_commit;
 
 void init_draw(int master, const char *path_getmode);
+void write_getmode(int mode);
 void update_backtick(void);
 int draw(void);
 void draw_statusline_restore(void);

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -120,6 +120,7 @@
 #endif
 
 #include <uim/uim.h>
+#include <uim/uim-internal.h>
 
 #include "udsock.h"
 #include "str.h"
@@ -189,6 +190,9 @@ static void set_signal_handler(void);
 static void reset_signal_handler(void);
 static void signal_handler(int sig_no);
 static void recover(void);
+static int fatal_error_occurred(void);
+static void reset_getmode(void);
+static void recover_if_fatal(void);
 static void sigtstp_handler(void);
 static void sigwinch_handler(void);
 static void sigusr1_handler(void);
@@ -1221,12 +1225,14 @@ static void main_loop(void)
       }
     }
 
+    recover_if_fatal();
 
     /* キーボード(stdin)からの入力 */
     if (FD_ISSET(g_win_in, &fds)) {
       int key_state = 0;
       if (!g_focus_in) {
         focus_in();
+        recover_if_fatal();
       }
 
       if ((len = read_stdin(buf, sizeof(buf) - 1)) == -1 || len == 0) {
@@ -1322,6 +1328,7 @@ static void main_loop(void)
             int raw;
             if (key != UKey_Focus && key != UKey_Other) {
               raw = press_key(key, key_state);
+              recover_if_fatal();
               if (!draw()) {
                 if (g_opt.status_type == BACKTICK) {
                   update_backtick();
@@ -1383,6 +1390,7 @@ static void main_loop(void)
 
     if (g_helper_fd >= 0 && FD_ISSET(g_helper_fd, &fds)) {
       helper_handler();
+      recover_if_fatal();
       draw();
     }
   }
@@ -1555,12 +1563,43 @@ static int child_exited(void)
 
 static void recover(void)
 {
+  reset_getmode();
+  recover_display();
   reset_signal_handler();
-  put_exit_attribute_mode();
-  put_restore_cursor();
-  put_cursor_normal();
+  quit_escseq();
   recover_loop();
   done(EXIT_SUCCESS);
+}
+
+static int fatal_error_occurred(void)
+{
+#if UIM_USE_ERROR_GUARD
+  return uim_caught_fatal_error();
+#else
+  return FALSE;
+#endif
+}
+
+static void reset_getmode(void)
+{
+  FILE *fp;
+
+  if (s_path_getmode[0] == '\0') {
+    return;
+  }
+
+  fp = fopen(s_path_getmode, "wt");
+  if (fp != NULL) {
+    fprintf(fp, "0\n");
+    fclose(fp);
+  }
+}
+
+static void recover_if_fatal(void)
+{
+  if (fatal_error_occurred()) {
+    recover();
+  }
 }
 
 /*
@@ -1616,10 +1655,14 @@ static void sigwinch_handler(void)
 
 void done(int exit_value)
 {
+  int fatal = fatal_error_occurred();
+
   flush_pending_pty_sequence();
-  uim_quit();
+  if (!fatal) {
+    uim_quit();
+    quit_helper();
+  }
   quit_escseq();
-  quit_helper();
   if (g_opt.status_type == BACKTICK) {
     clear_backtick();
   }

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -190,7 +190,6 @@ static void set_signal_handler(void);
 static void reset_signal_handler(void);
 static void signal_handler(int sig_no);
 static void recover(void);
-static int fatal_error_occurred(void);
 static void reset_getmode(void);
 static void recover_if_fatal(void);
 static void sigtstp_handler(void);
@@ -1571,15 +1570,6 @@ static void recover(void)
   done(EXIT_SUCCESS);
 }
 
-static int fatal_error_occurred(void)
-{
-#if UIM_USE_ERROR_GUARD
-  return uim_caught_fatal_error();
-#else
-  return FALSE;
-#endif
-}
-
 static void reset_getmode(void)
 {
   FILE *fp;
@@ -1597,9 +1587,11 @@ static void reset_getmode(void)
 
 static void recover_if_fatal(void)
 {
-  if (fatal_error_occurred()) {
+#if UIM_USE_ERROR_GUARD
+  if (uim_caught_fatal_error()) {
     recover();
   }
+#endif
 }
 
 /*

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -1402,12 +1402,13 @@ static void recover_loop(void)
   char buf[BUFSIZE];
   ssize_t len;
   fd_set fds;
+  int nfd = (g_win_in > s_master ? g_win_in : s_master) + 1;
 
   while (TRUE) {
     FD_ZERO(&fds);
     FD_SET(g_win_in, &fds);
     FD_SET(s_master, &fds);
-    if (select(s_master + 1, &fds, NULL, NULL, NULL) <= 0) {
+    if (select(nfd, &fds, NULL, NULL, NULL) <= 0) {
       /* signalで割り込まれたときにくる。selectの返り値は-1でerrno==EINTR */
       continue;
     }

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -190,7 +190,6 @@ static void set_signal_handler(void);
 static void reset_signal_handler(void);
 static void signal_handler(int sig_no);
 static void recover(void);
-static void reset_getmode(void);
 static void recover_if_fatal(void);
 static void sigtstp_handler(void);
 static void sigwinch_handler(void);
@@ -1562,27 +1561,12 @@ static int child_exited(void)
 
 static void recover(void)
 {
-  reset_getmode();
+  write_getmode(0);
   recover_display();
   reset_signal_handler();
   quit_escseq();
   recover_loop();
   done(EXIT_SUCCESS);
-}
-
-static void reset_getmode(void)
-{
-  FILE *fp;
-
-  if (s_path_getmode[0] == '\0') {
-    return;
-  }
-
-  fp = fopen(s_path_getmode, "wt");
-  if (fp != NULL) {
-    fprintf(fp, "0\n");
-    fclose(fp);
-  }
 }
 
 static void recover_if_fatal(void)

--- a/fep/uim-fep.c
+++ b/fep/uim-fep.c
@@ -1655,13 +1655,9 @@ static void sigwinch_handler(void)
 
 void done(int exit_value)
 {
-  int fatal = fatal_error_occurred();
-
   flush_pending_pty_sequence();
-  if (!fatal) {
-    uim_quit();
-    quit_helper();
-  }
+  uim_quit();
+  quit_helper();
   quit_escseq();
   if (g_opt.status_type == BACKTICK) {
     clear_backtick();


### PR DESCRIPTION
### Summary

When libuim enters its fatal-error state while `uim-fep` is displaying a preedit or status line, recover the terminal state and switch `uim-fep` to transparent pass-through mode instead of leaving the terminal apparently frozen.

### Problem

After a fatal error in the Scheme interpreter, libuim disables further functionality for the lifetime of the process. However, the `uim-fep` event loop may continue running, leaving:

- the current preedit visible on the terminal;
- the status line or backtick display stale;
- `UIM_FEP_GETMODE` set to the previous input mode;
- the terminal in a state where input appears to be blocked.

Calling normal libuim cleanup functions after a fatal error is also unsafe because libuim APIs are no longer usable.

### Changes

- Check for fatal libuim errors at the relevant points in the `uim-fep` event loop, including key processing and helper message handling.
- Erase the current preedit and status display before recovery.
- Clear the backtick display when applicable.
- Reset `UIM_FEP_GETMODE` to `0`.
- Restore terminal state and enter transparent pass-through mode.
- Avoid calling `uim_quit()` and helper cleanup functions after a fatal error.

### Testing

- Confirmed that fatal recovery clears the FEP-owned display state and prevents the terminal from remaining stuck in the previous input mode.